### PR TITLE
Fix aspect viewport uniforms

### DIFF
--- a/src/materials/SpriteBasicMaterial.js
+++ b/src/materials/SpriteBasicMaterial.js
@@ -18,8 +18,7 @@ export class SpriteBasicMaterial extends CustomShaderMaterial {
 
         this._spriteSize = new Vector2(1, 1);//deprecated
         this.setUniform("spriteSize", args.spriteSize ? args.spriteSize : [1.0, 1.0]);
-        this.setUniform("aspect", args.aspect ? args.aspect : window.innerWidth/window.innerHeight);
-        this.setUniform("viewport", args.viewport ? args.viewport : [window.innerWidth, window.innerHeight]);
+        // Uniforms aspect and viewport set by MeshRenderer based on actual viewport
         this.setUniform("MODE", args.mode ? args.mode : SPRITE_SPACE_SCREEN);
         this.setAttribute("deltaOffset", args.baseGeometry ? SpriteBasicMaterial._setupDeltaDirections(args.baseGeometry) : null);
     }

--- a/src/objects/Stripe.js
+++ b/src/objects/Stripe.js
@@ -25,7 +25,7 @@ export class Stripe extends Mesh {
         material.setAttribute("prevPosition", new Float32Attribute(stripeVertex.stripePrevPosition, points.itemSize));
         material.setAttribute("nextPosition", new Float32Attribute(stripeVertex.stripeNextPosition, points.itemSize));
         material.setAttribute("normalDirection", new Float32Attribute(stripeVertex.stripeNormalDirection, 1));
-        material.setUniform("aspect", window.innerWidth/window.innerHeight);
+        // Uniform aspect set by MeshRenderer based on actual viewport
         material.setUniform("lineWidth", 1.0);
 
         super(geometry, material, pickingMaterial);
@@ -37,7 +37,7 @@ export class Stripe extends Mesh {
         this.outline.material.setAttribute("prevPosition", new Float32Attribute(stripeVertex.stripePrevPosition, points.itemSize));
         this.outline.material.setAttribute("nextPosition", new Float32Attribute(stripeVertex.stripeNextPosition, points.itemSize));
         this.outline.material.setAttribute("normalDirection", new Float32Attribute(stripeVertex.stripeNormalDirection, 1));
-        this.outline.material.setUniform("aspect", window.innerWidth/window.innerHeight);
+        // Uniform aspect set by MeshRenderer based on actual viewport
         this.outline.material.lineWidth = this.material.lineWidth * 1.1;
 
         this._dashed = false;

--- a/src/objects/Text2D.js
+++ b/src/objects/Text2D.js
@@ -29,8 +29,7 @@ export class Text2D extends Mesh{
             this.geometry = this.setText2D(this._text, this._xPos, this._yPos, this._fontSize);
             this.material = new Text2DMaterial();
             this.material.setAttribute("deltaOffset", []);
-            this.material.setUniform("aspect", window.innerWidth/window.innerHeight);
-            this.material.setUniform("viewport", [window.innerWidth, window.innerHeight]);
+            // Uniforms aspect and viewport set by MeshRenderer based on actual viewport
             this.material.setUniform("MODE", TEXT2D_SPACE_SCREEN);
 
             this.material.addMap(this._fontTexture);
@@ -158,8 +157,7 @@ export class Text2D extends Mesh{
         const material = new Text2DMaterial();
 
         material.setAttribute("deltaOffset", Text2D._setupDeltaDirections(args.text, args.fontSize, args.offset));
-        material.setUniform("aspect", window.innerWidth/window.innerHeight);
-        material.setUniform("viewport", [window.innerWidth, window.innerHeight]);
+        // Uniforms aspect and viewport set by MeshRenderer based on actual viewport
         material.setUniform("MODE", args.mode);
 
         return material;

--- a/src/renderers/MeshRenderer.js
+++ b/src/renderers/MeshRenderer.js
@@ -537,6 +537,14 @@ export class MeshRenderer extends Renderer {
 		if (uniformSetter["pickingColor"] !== undefined) {
 			uniformSetter["pickingColor"].set(object.colorID.toArray());
 		}
+		if (uniformSetter["aspect"] !== undefined) {
+			console.log ("MeshRenderer: Setting aspect", this._viewport.width / this._viewport.height);
+			uniformSetter["aspect"].set(this._viewport.width / this._viewport.height);
+		}
+		if (uniformSetter["viewport"] !== undefined) {
+			console.log ("MeshRenderer: Setting viewport", this._viewport.width, this._viewport.height);
+			uniformSetter["viewport"].set([ this._viewport.width, this._viewport.height ]);
+		}
 		if (uniformSetter["scale"] !== undefined) {
 			uniformSetter["scale"].set(object.scale.toArray());
 		}

--- a/src/renderers/MeshRenderer.js
+++ b/src/renderers/MeshRenderer.js
@@ -538,11 +538,9 @@ export class MeshRenderer extends Renderer {
 			uniformSetter["pickingColor"].set(object.colorID.toArray());
 		}
 		if (uniformSetter["aspect"] !== undefined) {
-			console.log ("MeshRenderer: Setting aspect", this._viewport.width / this._viewport.height);
 			uniformSetter["aspect"].set(this._viewport.width / this._viewport.height);
 		}
 		if (uniformSetter["viewport"] !== undefined) {
-			console.log ("MeshRenderer: Setting viewport", this._viewport.width, this._viewport.height);
 			uniformSetter["viewport"].set([ this._viewport.width, this._viewport.height ]);
 		}
 		if (uniformSetter["scale"] !== undefined) {


### PR DESCRIPTION
Use correct aspect and viewport uniforms at the time of rendering.

- Add handling of "aspect" and "viewport" uniforms to MeshRenderer.
- Remove setting to window.width/height at creation time for Stripe, Sprite, and Text2D.
  Leave comments about those uniforms being defined at render time.
