### PR TITLE
Use uint32 picking ID for a Mesh

### DIFF
--- a/src/core/GLTextureManager.js
+++ b/src/core/GLTextureManager.js
@@ -267,6 +267,15 @@ export class GLTextureManager {
 			case Texture.R16F:
 				return this._gl.R16F;
 				break;
+			case Texture.R32F:
+				return this._gl.R32F;
+				break;
+			case Texture.R32I:
+				return this._gl.R32I;
+				break;
+			case Texture.R32UI:
+				return this._gl.R32UI;
+				break;
 			default:
 				console.warn("----------------------------------------------");
 				console.warn("Warning: Received unsupported texture format: [" + format + "]!");

--- a/src/core/GLTextureManager.js
+++ b/src/core/GLTextureManager.js
@@ -228,6 +228,9 @@ export class GLTextureManager {
 			case Texture.RED:
 				return this._gl.RED;
 				break;
+			case Texture.RED_INTEGER:
+				return this._gl.RED_INTEGER;
+				break;
 			case Texture.RGBA:
 				return this._gl.RGBA;
 				break;

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -18,6 +18,8 @@ import {Mesh} from "../objects/Mesh.js";
 
 export class Object3D {
 
+	static sDefaultPickable = true;
+
 	constructor() {
 
 		// Self reference for callbacks
@@ -81,7 +83,7 @@ export class Object3D {
 		this._isStatic = false;
 		this._staticStateDirty = true;
 		this._renderingPrimitive = TRIANGLES;	//default rendering primitive
-		this._pickable = true;
+		this._pickable = Object3D.sDefaultPickable;
 		this._zVector = new Vector3();
 		this._boundingSphere = new Sphere(new Vector3(0, 0, 0), Infinity);
 	}

--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -130,15 +130,7 @@ export class Mesh extends Object3D {
 	}
 
 	set pickID(pid) {
-		if (typeof pid === 'number') {
-			this._pickID = [];
-			for (let i = 0; i < 4; ++i) {
-				this._pickID.push((pid & 255) / 255);
-				pid = pid >>> 8;
-			}
-		} else {
-			this._pickID = pid;
-		}
+		this._pickID = pid;
 	}
 	set outline(outline) {
 		this.remove(this._outline);	//remove current outline

--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -38,7 +38,7 @@ export class Mesh extends Object3D {
 		this._outlineMaterial = outlineMaterial !== undefined ? outlineMaterial : new OutlineBasicMaterial();
 
 		this.raycast = _raycast;
-		this._colorID = new Color(Math.random() * 0xffffff);
+		this._pickID = null; // stored as float [ R, G, B, A ], can represent full uint32 excluding 0
 
 		//OUTLINE
 		this._useOutline = false; //outline object visibility
@@ -84,7 +84,7 @@ export class Mesh extends Object3D {
 	 * @returns Geometry of the mesh.
 	 */
 	get geometry() { return this._geometry; }
-	get colorID() { return this._colorID; }
+	get pickID() { return this._pickID; }
 	get outline() { return this._outline; }
 	get useOutline() { return this._useOutline; }
 
@@ -129,7 +129,17 @@ export class Mesh extends Object3D {
 		this._material.onChangeListener = listener;
 	}
 
-	set colorID(colorID){ this._colorID = colorID; }
+	set pickID(pid) {
+		if (typeof pid === 'number') {
+			this._pickID = [];
+			for (let i = 0; i < 4; ++i) {
+				this._pickID.push((pid & 255) / 255);
+				pid = pid >>> 8;
+			}
+		} else {
+			this._pickID = pid;
+		}
+	}
 	set outline(outline) {
 		this.remove(this._outline);	//remove current outline
 		this._outline = outline;

--- a/src/program_management/GLProgramManager.js
+++ b/src/program_management/GLProgramManager.js
@@ -373,7 +373,9 @@ export class GLProgramManager {
 					};
 					break;
 				case self._gl.SAMPLER_2D:
-					uniformSetter[info.name]['set'] = function (texture, index) {
+				case self._gl.INT_SAMPLER_2D:
+				case self._gl.UNSIGNED_INT_SAMPLER_2D:
+						uniformSetter[info.name]['set'] = function (texture, index) {
 						self._gl.activeTexture(self._gl.TEXTURE0 + index);
 						self._gl.bindTexture(self._gl.TEXTURE_2D, texture);
 						self._gl.uniform1i(location, index);

--- a/src/program_management/GLProgramManager.js
+++ b/src/program_management/GLProgramManager.js
@@ -321,6 +321,22 @@ export class GLProgramManager {
 					}
 					break;
 
+				case self._gl.UNSIGNED_INT:
+					if (info.size > 1) {
+						// Array
+						uniformSetter[info.name]['set'] = function (value) {
+							self._gl.uniform1uiv(location, value);
+							uniformSetter.__validation.uniforms[info.name] = true;
+						};
+					}
+					else {
+						uniformSetter[info.name]['set'] = function (value) {
+							self._gl.uniform1ui(location, value);
+							uniformSetter.__validation.uniforms[info.name] = true;
+						};
+					}
+					break;
+
 				case self._gl.INT_VEC2:
 					if (info.size > 1) {
 						// Array
@@ -375,7 +391,7 @@ export class GLProgramManager {
 				case self._gl.SAMPLER_2D:
 				case self._gl.INT_SAMPLER_2D:
 				case self._gl.UNSIGNED_INT_SAMPLER_2D:
-						uniformSetter[info.name]['set'] = function (texture, index) {
+					uniformSetter[info.name]['set'] = function (texture, index) {
 						self._gl.activeTexture(self._gl.TEXTURE0 + index);
 						self._gl.bindTexture(self._gl.TEXTURE_2D, texture);
 						self._gl.uniform1i(location, index);

--- a/src/renderers/FX/PickerFX.js
+++ b/src/renderers/FX/PickerFX.js
@@ -80,7 +80,7 @@ export class PickerFX extends FX {
             "depth_color_picker",
 
             [
-                {id: OUTPUTS.color.name, textureConfig: RenderPass.DEFAULT_RGBA_TEXTURE_CONFIG},
+                {id: OUTPUTS.color.name, textureConfig: RenderPass.DEFAULT_R32UI_TEXTURE_CONFIG},
             ]
         );
 

--- a/src/renderers/RenderPass.js
+++ b/src/renderers/RenderPass.js
@@ -156,6 +156,24 @@ RenderPass.DEFAULT_R8_TEXTURE_CONFIG = {
 	format: Texture.RED,
 	type: Texture.UNSIGNED_BYTE
 };
+RenderPass.DEFAULT_R32I_TEXTURE_CONFIG = {
+	wrapS: Texture.ClampToEdgeWrapping,
+	wrapT: Texture.ClampToEdgeWrapping,
+	minFilter: Texture.LinearFilter,
+	magFilter: Texture.LinearFilter,
+	internalFormat: Texture.R32I,
+	format: Texture.RED,
+	type: Texture.INT
+};
+RenderPass.DEFAULT_R32UI_TEXTURE_CONFIG = {
+	wrapS: Texture.ClampToEdgeWrapping,
+	wrapT: Texture.ClampToEdgeWrapping,
+	minFilter: Texture.LinearFilter,
+	magFilter: Texture.LinearFilter,
+	internalFormat: Texture.R32UI,
+	format: Texture.RED,
+	type: Texture.UNSIGNED_INT
+};
 RenderPass.DEFAULT_RGB_TEXTURE_CONFIG = {
 	wrapS: Texture.ClampToEdgeWrapping,
 	wrapT: Texture.ClampToEdgeWrapping,
@@ -266,4 +284,13 @@ RenderPass.FULL_FLOAT_RGB_NEAREST_TEXTURE_CONFIG = {
 	type: Texture.FLOAT
 };
 
-
+//32F
+RenderPass.FULL_FLOAT_R32F_TEXTURE_CONFIG = {
+	wrapS: Texture.ClampToEdgeWrapping,
+	wrapT: Texture.ClampToEdgeWrapping,
+	minFilter: Texture.LinearFilter,
+	magFilter: Texture.LinearFilter,
+	internalFormat: Texture.R32F,
+	format: Texture.RED,
+	type: Texture.FLOAT
+};

--- a/src/renderers/RenderPass.js
+++ b/src/renderers/RenderPass.js
@@ -171,7 +171,7 @@ RenderPass.DEFAULT_R32UI_TEXTURE_CONFIG = {
 	minFilter: Texture.LinearFilter,
 	magFilter: Texture.LinearFilter,
 	internalFormat: Texture.R32UI,
-	format: Texture.RED,
+	format: Texture.RED_INTEGER,
 	type: Texture.UNSIGNED_INT
 };
 RenderPass.DEFAULT_RGB_TEXTURE_CONFIG = {

--- a/src/renderers/RenderTarget.js
+++ b/src/renderers/RenderTarget.js
@@ -72,9 +72,9 @@ export class RenderTarget {
 				Texture.ClampToEdgeWrapping,
 				Texture.NearestFilter,
 				Texture.NearestFilter,
-				Texture.DEPTH_COMPONENT24,
+				Texture.DEPTH_COMPONENT32F,
 				Texture.DEPTH_COMPONENT,
-				Texture.UNSIGNED_INT,
+				Texture.FLOAT,
 				this._width,
 				this._height
 			);

--- a/src/shaders/color_picker/color_picker.frag
+++ b/src/shaders/color_picker/color_picker.frag
@@ -2,11 +2,11 @@
 precision mediump float;
 
 
-uniform vec3 pickingColor;
+uniform vec4 pickingColor;
 
 out vec4 color;
 
 
 void main() {
-    color = vec4(pickingColor, 1.0);
+    color = pickingColor;
 }

--- a/src/shaders/color_picker/color_picker.frag
+++ b/src/shaders/color_picker/color_picker.frag
@@ -2,11 +2,11 @@
 precision mediump float;
 
 
-uniform vec4 pickingColor;
+uniform uint pickingID;
 
-out vec4 color;
+layout(location = 0) out uint objID;
 
 
 void main() {
-    color = pickingColor;
+    objID = pickingID;
 }

--- a/src/shaders/color_picker/color_picker_POINTS.frag
+++ b/src/shaders/color_picker/color_picker_POINTS.frag
@@ -2,9 +2,9 @@
 precision mediump float;
 
 
-uniform vec4 pickingColor;
+uniform uint pickingID;
 
-out vec4 color;
+layout(location = 0) out uint objID;
 
 
 void main() {
@@ -17,6 +17,5 @@ void main() {
         }
     #fi
 
-
-    color = pickingColor;
+    objID = pickingID;
 }

--- a/src/shaders/color_picker/color_picker_POINTS.frag
+++ b/src/shaders/color_picker/color_picker_POINTS.frag
@@ -2,7 +2,7 @@
 precision mediump float;
 
 
-uniform vec3 pickingColor;
+uniform vec4 pickingColor;
 
 out vec4 color;
 
@@ -18,5 +18,5 @@ void main() {
     #fi
 
 
-    color = vec4(pickingColor, 1.0);
+    color = pickingColor;
 }

--- a/src/shaders/color_picker/color_picker_TRIANGLES.frag
+++ b/src/shaders/color_picker/color_picker_TRIANGLES.frag
@@ -2,11 +2,11 @@
 precision mediump float;
 
 
-uniform vec3 pickingColor;
+uniform vec4 pickingColor;
 
 out vec4 color;
 
 
 void main() {
-    color = vec4(pickingColor, 1.0);
+    color = pickingColor;
 }

--- a/src/shaders/color_picker/color_picker_TRIANGLES.frag
+++ b/src/shaders/color_picker/color_picker_TRIANGLES.frag
@@ -2,11 +2,11 @@
 precision mediump float;
 
 
-uniform vec4 pickingColor;
+uniform uint pickingID;
 
-out vec4 color;
+layout(location = 0) out uint objID;
 
 
 void main() {
-    color = pickingColor;
+    objID = pickingID;
 }

--- a/src/shaders/color_picker/color_picker_hit.frag
+++ b/src/shaders/color_picker/color_picker_hit.frag
@@ -3,7 +3,7 @@ precision mediump float;
 precision highp int;
 
 
-uniform vec3 pickingColor;
+uniform vec4 pickingColor;
 
 
 out vec4 color;
@@ -18,5 +18,5 @@ void main() {
     }
 
 
-    color = vec4(pickingColor, 1.0);
+    color = pickingColor;
 }

--- a/src/shaders/color_picker/color_picker_hit.frag
+++ b/src/shaders/color_picker/color_picker_hit.frag
@@ -3,10 +3,9 @@ precision mediump float;
 precision highp int;
 
 
-uniform vec4 pickingColor;
+uniform uint pickingID;
 
-
-out vec4 color;
+layout(location = 0) out uint objID;
 
 
 void main() {
@@ -18,5 +17,5 @@ void main() {
     }
 
 
-    color = pickingColor;
+    objID = pickingID;
 }

--- a/src/shaders/color_picker/color_picker_particle.frag
+++ b/src/shaders/color_picker/color_picker_particle.frag
@@ -3,7 +3,7 @@ precision mediump float;
 precision highp int;
 
 
-uniform vec3 pickingColor;
+uniform vec4 pickingColor;
 
 
 out vec4 color;
@@ -18,5 +18,5 @@ void main() {
     }
 
 
-    color = vec4(pickingColor, 1.0);
+    color = pickingColor;
 }

--- a/src/shaders/color_picker/color_picker_particle.frag
+++ b/src/shaders/color_picker/color_picker_particle.frag
@@ -3,10 +3,9 @@ precision mediump float;
 precision highp int;
 
 
-uniform vec4 pickingColor;
+uniform uint pickingID;
 
-
-out vec4 color;
+layout(location = 0) out uint objID;
 
 
 void main() {
@@ -18,5 +17,5 @@ void main() {
     }
 
 
-    color = pickingColor;
+    objID = pickingID;
 }

--- a/src/shaders/color_picker/color_picker_stripe.frag
+++ b/src/shaders/color_picker/color_picker_stripe.frag
@@ -2,11 +2,11 @@
 precision mediump float;
 
 
-uniform vec3 pickingColor;
+uniform vec4 pickingColor;
 
 out vec4 color;
 
 
 void main() {
-    color = vec4(pickingColor, 1.0);
+    color = pickingColor;
 }

--- a/src/shaders/color_picker/color_picker_stripe.frag
+++ b/src/shaders/color_picker/color_picker_stripe.frag
@@ -2,11 +2,11 @@
 precision mediump float;
 
 
-uniform vec4 pickingColor;
+uniform uint pickingID;
 
-out vec4 color;
+layout(location = 0) out uint objID;
 
 
 void main() {
-    color = pickingColor;
+    objID = pickingID;
 }

--- a/src/shaders/color_picker/color_picker_track_width.frag
+++ b/src/shaders/color_picker/color_picker_track_width.frag
@@ -2,11 +2,11 @@
 precision mediump float;
 
 
-uniform vec3 pickingColor;
+uniform vec4 pickingColor;
 
 out vec4 color;
 
 
 void main() {
-    color = vec4(pickingColor, 1.0);
+    color = pickingColor;
 }

--- a/src/shaders/color_picker/color_picker_track_width.frag
+++ b/src/shaders/color_picker/color_picker_track_width.frag
@@ -2,11 +2,11 @@
 precision mediump float;
 
 
-uniform vec4 pickingColor;
+uniform uint pickingID;
 
-out vec4 color;
+layout(location = 0) out uint objID;
 
 
 void main() {
-    color = pickingColor;
+    objID = pickingID;
 }

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -178,7 +178,9 @@ Object.assign(Texture, {
 	R16F : 17,
 	R8: 17.1,
 	RED: 17.2,
-
+	R32F : 17.3,
+	R32I : 17.4,
+	R32UI : 17.5,
 
 // WRAPPING
 	RepeatWrapping : 18,
@@ -190,7 +192,8 @@ Object.assign(Texture, {
 	UNSIGNED_SHORT : 22,		// Depth (default)
 	UNSIGNED_INT : 23,
 	HALF_FLOAT : 24,
-	FLOAT : 25
+	FLOAT : 25,
+	INT : 26
 
 /** NOTE
  * Only following formats can be added as color attachments

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -178,6 +178,7 @@ Object.assign(Texture, {
 	R16F : 17,
 	R8: 17.1,
 	RED: 17.2,
+	RED_INTEGER: 17.25,
 	R32F : 17.3,
 	R32I : 17.4,
 	R32UI : 17.5,


### PR DESCRIPTION
- Mesh.pickID can now be plain scalar / uint32 - no need for color / arrays / vec uniforms.
- Rename Mesh::colorID to pickID.

Somewhat related changes:
- Control default state of Object3D::pickable via static sDefaultPickable.
- Add MeshRenderer.pickDoNotRender flag that makes render function exit after picking.
