### PR TITLE
Fix MeshRenderer picking, optionally disable perspective point-size scaling

### DIFF
--- a/src/materials/CustomShaderMaterial.js
+++ b/src/materials/CustomShaderMaterial.js
@@ -55,7 +55,7 @@ export class CustomShaderMaterial  extends Material {
 		delete this._valuesSB[name];
 	}
 
-	clearSBFlags() {
+	clearSBValues() {
 		this._valuesSB = {};
 	}
 

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -42,7 +42,8 @@ export class Material {
 
 		// Using points
 		this._usePoints = false;
-        this._pointSize = 1.0;
+		this._pointSize = 1.0;
+		this._pointsScale = true;
 		this._drawCircles = false;
 		// Using clipping planes
 		this._useClippingPlanes = false;
@@ -201,6 +202,36 @@ export class Material {
         }
     }
 
+	set pointsScale(val){
+		if (val !== this._pointsScale) {
+			// Invalidate required program template
+			this._requiredProgramTemplate = null;
+
+			this._pointsScale = val;
+
+			// Notify onChange subscriber
+			if (this._onChangeListener) {
+				var update = {uuid: this._uuid, changes: {pointsScale: this._pointsScale}};
+				this._onChangeListener.materialUpdate(update)
+			}
+		}
+	}
+
+	set drawCircles(val){
+		if (val !== this._drawCircles) {
+			// Invalidate required program template
+			this._requiredProgramTemplate = null;
+
+			this._drawCircles = val;
+
+			// Notify onChange subscriber
+			if (this._onChangeListener) {
+				var update = {uuid: this._uuid, changes: {drawCircles: this._drawCircles}};
+				this._onChangeListener.materialUpdate(update)
+			}
+		}
+	}
+
 	set useClippingPlanes(val){
 		if (val !== this._useClippingPlanes) {
 			// Invalidate required program template
@@ -339,21 +370,8 @@ export class Material {
 	get useVertexColors() { return this._useVertexColors; }
 	get usePoints() {return this._usePoints;}
 	get pointSize() {return this._pointSize;}
+	get pointsScale() {return this._pointsScale;}
 	get drawCircles(){ return this._drawCircles; }
-	set drawCircles(val){
-		if (val !== this._drawCircles) {
-			// Invalidate required program template
-			this._requiredProgramTemplate = null;
-
-			this._drawCircles = val;
-
-			// Notify onChange subscriber
-			if (this._onChangeListener) {
-				var update = {uuid: this._uuid, changes: {drawCircles: this._drawCircles}};
-				this._onChangeListener.materialUpdate(update)
-			}
-		}
-	}
 	get useClippingPlanes() {return this._useClippingPlanes;}
 	get clippingPlanes() {return this._clippingPlanes;}
 	get shadingType() {return this._shadingType;}
@@ -520,6 +538,7 @@ export class Material {
 			this._flags.push("FRONT_AND_BACK_SIDE");
 		}
 		if(this._usePoints) this._flags.push("POINTS");
+		if(this._pointsScale) this._flags.push("POINTS_SCALE");
 		if(this._drawCircles) this.flags.push("CIRCLES");
 		if(this._useClippingPlanes){
 			this._flags.push("CLIPPING_PLANES");
@@ -639,6 +658,10 @@ export class Material {
                     this._pointSize = data.pointSize;
                     delete data.pointSize;
                     break;
+				case "pointsScale":
+					this._pointsScale = data.pointsScale;
+					delete data.pointsScale;
+					break;
 				case "drawCircles":
 					this._drawCircles = data.drawCircles;
 					delete data.drawCircles;

--- a/src/materials/PickingShaderMaterial.js
+++ b/src/materials/PickingShaderMaterial.js
@@ -12,8 +12,7 @@ export class PickingShaderMaterial extends CustomShaderMaterial {
         RGB: 0,
         UINT: 1
     };
-
-
+    static DEFAULT_PICK_MODE = PickingShaderMaterial.PICK_MODE.RGB;
     constructor(programName = "TRIANGLES", uniforms = {}, attributes = {}, args = {}) {
         super("picker" + '_' + programName, uniforms, attributes, args);
 
@@ -25,7 +24,7 @@ export class PickingShaderMaterial extends CustomShaderMaterial {
 
 
         // set
-        this.pickMode = args.mode ? args.mode : PickingShaderMaterial.PICK_MODE.RGB;
+        this.pickMode = args.mode ? args.mode : PickingShaderMaterial.DEFAULT_PICK_MODE;
     }
 
 

--- a/src/objects/Geometry.js
+++ b/src/objects/Geometry.js
@@ -770,7 +770,7 @@ export class Geometry {
 	 * @returns Minimal bounding sphere.
 	 */
 	get boundingSphere() {
-		// If the bounding sphere was not jet computed compute it
+		// If the bounding sphere was not yet computed compute it
 		if (this._boundingSphere === null) {
 			this.computeBoundingSphere();
 		}
@@ -783,7 +783,7 @@ export class Geometry {
 	/**
 	 * Set geometry indices.
 	 *
-	 * @param values Geometry ndices.
+	 * @param values Geometry indices.
 	 */
 	set indices(values) {
 		this._indices = values;

--- a/src/renderers/MeshRenderer.js
+++ b/src/renderers/MeshRenderer.js
@@ -373,7 +373,7 @@ export class MeshRenderer extends Renderer {
 			if(!object.pickable) continue;
 
 			if (this._pickObject3D) {
-				object.pickID = ++this._pickAutoID;
+				object.UINT_ID = ++this._pickAutoID;
 				this._pickLUA.push(object);
 			}
 

--- a/src/shaders/basic/basic_template-FLAT.vert
+++ b/src/shaders/basic/basic_template-FLAT.vert
@@ -203,7 +203,11 @@ void main() {
 
 
     #if (POINTS)
-        gl_PointSize = pointSize / length(VPos_viewspace.xyz);
+        #if (POINTS_SCALE)
+            gl_PointSize = pointSize / length(VPos_viewspace.xyz);
+        #else
+            gl_PointSize = pointSize;
+        #fi
         if(gl_PointSize < 1.0) gl_PointSize = 1.0;
     #fi
 

--- a/src/shaders/basic/basic_template.vert
+++ b/src/shaders/basic/basic_template.vert
@@ -97,7 +97,11 @@ void main() {
     #fi
 
     #if (POINTS)
-        gl_PointSize = pointSize / length(VPos4.xyz);
+        #if (POINTS_SCALE)
+            gl_PointSize = pointSize / length(VPos4.xyz);
+        #else
+            gl_PointSize = pointSize;
+        #fi
         if(gl_PointSize < 1.0) gl_PointSize = 1.0;
     #fi
 

--- a/src/shaders/picker/picker_POINTS.vert
+++ b/src/shaders/picker/picker_POINTS.vert
@@ -41,6 +41,10 @@ void main() {
     gl_Position = PMat * VPos4;
 
 
-    gl_PointSize = pointSize / length(VPos4.xyz);
+    #if (POINTS_SCALE)
+        gl_PointSize = pointSize / length(VPos4.xyz);
+    #else
+        gl_PointSize = pointSize;
+    #fi
     if(gl_PointSize < 1.0) gl_PointSize = 1.0;
 }


### PR DESCRIPTION
1. Fix MeshRenderer uint picking to work with the last picking shader changes.
   In PickingShaderMaterial add static variable to define default PICK_MODE.

2. For Point rendering, add flag POINTS_SCALE and Material._pointsScale that
   can be used to disable perspective scaling of point sizes.
   Default was and still is true -- points are scaled perspectively.

3. Fix typos:
   - CustomShaderMaterial.js: clearSBFlags() -> clearSBValues() [flags declared twice]
   - Geometry.js: spelling in comment