### PR TITLE
Generalizations for instancing, picking and outlining as needed for REve

### DIFF
--- a/examples/outlineExample/main-ZSprite.js
+++ b/examples/outlineExample/main-ZSprite.js
@@ -266,6 +266,8 @@ const CoreControl = {
         sprite.instanced = true;
         sprite.instanceCount = this.tex_insta_num;
         sprite.drawOutline = true;
+        // outline only 100-th and first 10 odd ones, skipping instance 0.
+        sprite.outlineMaterial.outline_instances_setup([100, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20]);
         scene.add(sprite);
 
         let sm2 = new RC.ZSpriteBasicMaterial( { SpriteMode: RC.SPRITE_SPACE_WORLD, SpriteSize: [8, 8],
@@ -450,6 +452,7 @@ function iterateSceneR(object, callback) {
 
 const OriginalMats = [];
 const MultiMats = [];
+const InstaCountMap = new Map();
 const RenderPass_MainShader = new RC.RenderPass(
     // Rendering pass type
     RC.RenderPass.BASIC,
@@ -513,6 +516,8 @@ const RenderPass_MainMulti = new RC.RenderPass(
                     MultiMats.push(object._outlineMaterial);
                 else
                     MultiMats.push(multi);
+                if (object._instanced && object._outlineMaterial.getUniform("u_OutlineGivenInstances"))
+                    InstaCountMap.set(object, object._instanceCount);
             }
         });
     },
@@ -525,7 +530,8 @@ const RenderPass_MainMulti = new RC.RenderPass(
             if(object.drawOutline) {
                 object.material = MultiMats[m_index];
                 m_index++;
-
+                if (object._instanced && object._outlineMaterial.getUniform("u_OutlineGivenInstances"))
+                    object._instanceCount = object._outlineMaterial.getAttribute("a_OutlineInstances").count();
                 object.visible = true;
             }else if (object instanceof RC.Scene || object instanceof RC.Group){
                 object.visible = true;
@@ -538,6 +544,9 @@ const RenderPass_MainMulti = new RC.RenderPass(
     },
 
     function(textureMap, additionalData) {
+        for (const [key, value] of InstaCountMap) {
+            key._instanceCount = value;
+        }
     },
 
     // Target

--- a/examples/outlineExample/main-ZSprite.js
+++ b/examples/outlineExample/main-ZSprite.js
@@ -107,6 +107,7 @@ const CoreControl = {
             // RC.Texture.R32F, RC.Texture.R32F, RC.Texture.FLOAT,
             RC.Texture.RGBA32F, RC.Texture.RGBA, RC.Texture.FLOAT,
             Nx, Ny);
+        this.tex_insta_pos.flipy = false;
 
         // Testing creation of texture from JS array, simple checker pattern.
         let at = new Uint8Array(2 * 2 * 2);

--- a/src/RenderCore.js
+++ b/src/RenderCore.js
@@ -35,6 +35,7 @@ export {SphericalHarmonics3} from './math/SphericalHarmonics3.js';
 
 // Loaders
 export {Cache} from './loaders/Cache.js';
+export {ImageCache, TextureCache} from './loaders/ImageCache.js';
 export {LoadingManager} from './loaders/LoadingManager.js';
 export {XHRLoader} from './loaders/XHRLoader.js';
 export {ShaderLoader} from './loaders/ShaderLoader.js';

--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -16,15 +16,13 @@
 	 * @param array Buffer data.
 	 * @param itemSize Size of an item.
 	 */
-	constructor(array, itemSize) {
+	constructor(array, itemSize, divisor = 0) {
 		this._array = array;
 		this._itemSize = itemSize;
+		this._divisor = divisor; // Divisor used by instancing
 
 		// Tells if local copies are up to date
 		this._dirty = true;
-
-		//Divisor used by instancing
-		this._divisor = 0;
 
 		this._drawType = BufferAttribute.DRAW_TYPE.STATIC;
 		this._update = false;
@@ -103,38 +101,38 @@
 	}
 };
 
-export function Int8Attribute (array, itemSize) {
-	return new BufferAttribute(new Int8Array(array), itemSize);
+export function Int8Attribute (array, itemSize, divisor = 0) {
+	return new BufferAttribute(new Int8Array(array), itemSize, divisor);
 };
 
-export function Uint8Attribute (array, itemSize) {
-	return new BufferAttribute(new Uint8Array(array), itemSize);
+export function Uint8Attribute (array, itemSize, divisor = 0) {
+	return new BufferAttribute(new Uint8Array(array), itemSize, divisor);
 };
 
-export function Uint8ClampedAttribute (array, itemSize) {
-	return new BufferAttribute(new Uint8ClampedArray(array), itemSize);
+export function Uint8ClampedAttribute (array, itemSize, divisor = 0) {
+	return new BufferAttribute(new Uint8ClampedArray(array), itemSize, divisor);
 };
 
-export function Int16Attribute (array, itemSize) {
-	return new BufferAttribute(new Int16Array(array), itemSize);
+export function Int16Attribute (array, itemSize, divisor = 0) {
+	return new BufferAttribute(new Int16Array(array), itemSize, divisor);
 };
 
-export function Uint16Attribute (array, itemSize) {
-	return new BufferAttribute(new Uint16Array(array), itemSize);
+export function Uint16Attribute (array, itemSize, divisor = 0) {
+	return new BufferAttribute(new Uint16Array(array), itemSize, divisor);
 };
 
-export function Int32Attribute (array, itemSize) {
-	return new BufferAttribute(new Int32Array(array), itemSize);
+export function Int32Attribute (array, itemSize, divisor = 0) {
+	return new BufferAttribute(new Int32Array(array), itemSize, divisor);
 };
 
-export function Uint32Attribute (array, itemSize) {
-	return new BufferAttribute(new Uint32Array(array), itemSize);
+export function Uint32Attribute (array, itemSize, divisor = 0) {
+	return new BufferAttribute(new Uint32Array(array), itemSize, divisor);
 };
 
-export function Float32Attribute (array, itemSize) {
-	return new BufferAttribute(new Float32Array(array), itemSize);
+export function Float32Attribute (array, itemSize, divisor = 0) {
+	return new BufferAttribute(new Float32Array(array), itemSize, divisor);
 };
 
-export function Float64Attribute (array, itemSize) {
-	return new BufferAttribute(new Float64Array(array), itemSize);
+export function Float64Attribute (array, itemSize, divisor = 0) {
+	return new BufferAttribute(new Float64Array(array), itemSize, divisor);
 };

--- a/src/core/GLManager.js
+++ b/src/core/GLManager.js
@@ -81,6 +81,12 @@ export class GLManager {
 		}
 	}
 
+	updateCustomShaderAttributes(material) {
+		// Update GL version of all of the custom attributes
+		for (const name of Object.keys(material._attributes))
+			this._attributeManager.updateAttribute(material._attributes[name], this._gl.ARRAY_BUFFER);
+	}
+
 	/**
 	 * Updates object geometry attributes (creates GL buffers or updates them if they already exist)
 	 * @param object
@@ -169,14 +175,7 @@ export class GLManager {
 
 		// CustomShaderMaterial may specify extra attributes
 		if (object.material instanceof CustomShaderMaterial) {
-			let customAttributes = object.material._attributes;
-
-			// Update GL version of all of the custom attributes
-			for (let name in customAttributes) {
-				if (customAttributes.hasOwnProperty(name)) {
-					this._attributeManager.updateAttribute(customAttributes[name], this._gl.ARRAY_BUFFER);
-				}
-			}
+			this.updateCustomShaderAttributes(object.material);
 		}
 		//endregion
 	}

--- a/src/core/GLManager.js
+++ b/src/core/GLManager.js
@@ -91,7 +91,7 @@ export class GLManager {
 	 * Updates object geometry attributes (creates GL buffers or updates them if they already exist)
 	 * @param object
 	 */
-	updateObjectData(object) {
+	updateObjectData(object, material) {
 		// BufferedGeometry
 		let geometry = object.geometry;
 
@@ -141,9 +141,6 @@ export class GLManager {
 		}
 		// endregion
 
-		// region MATERIAL ATTRIBUTES
-		let material = object.material;
-
 		// Update textures
 		let textures = material.maps;
 
@@ -174,8 +171,8 @@ export class GLManager {
 		if (instanceData) this._textureManager.updateTexture(instanceData, false);
 
 		// CustomShaderMaterial may specify extra attributes
-		if (object.material instanceof CustomShaderMaterial) {
-			this.updateCustomShaderAttributes(object.material);
+		if (material instanceof CustomShaderMaterial) {
+			this.updateCustomShaderAttributes(material);
 		}
 		//endregion
 	}

--- a/src/core/GLTextureManager.js
+++ b/src/core/GLTextureManager.js
@@ -35,7 +35,7 @@ export class GLTextureManager {
 
 		this._gl.bindTexture(this._gl.TEXTURE_2D, glTexture);
 
-		this._gl.pixelStorei(this._gl.UNPACK_FLIP_Y_WEBGL, true);
+		this._gl.pixelStorei(this._gl.UNPACK_FLIP_Y_WEBGL, texture.flipy);
 
 		// Parse texture data
 		let internalFormat = this._formatToGL(texture._internalFormat);

--- a/src/loaders/ImageCache.js
+++ b/src/loaders/ImageCache.js
@@ -1,0 +1,145 @@
+/**
+ * Created by Matevz on 14.6.2022
+ * Based on Cache.js by Primoz
+ */
+
+/**
+ * This is a global object that can be used for caching of Images.
+ * Useful when it is known that the same image might be requested at the
+ * same time, potentially from different GL contexts / MeshRenderers.
+ * To be used along with a TextureCache on the level of individual MeshRenderer.
+ */
+
+export var ImageCache =
+{
+	cached: new Map,     // cached images
+	incoming: new Map,   // incoming URLs, when set contains an array of callbacks
+	verbose: false,
+
+	// callback takes 3 arguments: url, image, delayed
+	// Note: on error image returned will be null. This will also get cached.
+
+	deliver: function (url, callback)
+	{
+		if (this.verbose) console.log("ImageCache deliver", this.cacheid, url);
+
+		let img = this.cached.get(url);
+		if (img !== undefined) {
+			if (this.verbose) console.log("ImageCache HAS", url);
+			callback(url, img, false);
+			return;
+		}
+		let arr = this.incoming.get(url);
+		if (arr !== undefined) {
+			if (this.verbose) console.log("ImageCache EXPECTING", url);
+			arr.push(callback);
+			return;
+		}
+
+		if (this.verbose) console.log("ImageCache does NOT HAVE -- requesting", url);
+		this.incoming.set(url, [ callback ]);
+
+		let image = new Image();
+		let pthis = this;
+		image.onload  = () => { this.image_loaded(url, image); };
+		image.onerror = () => { this.image_loaded(url, null); }
+		image.src = url;
+	},
+
+	image_loaded: function (url, image)
+	{
+		if (image) {
+			if (this.verbose) console.log("ImageCache image_loaded success", url);
+		} else {
+			console.error("ImageCache image_loaded error loading", url);
+		}
+		this.cached.set(url, image);
+
+		// Notify all registered callacks.
+		let array = this.incoming.get(url);
+		for (let i = 0; i < array.length; ++i) {
+		   array[i](url, image, true);
+		}
+		this.incoming.delete(url);
+	},
+
+	remove: function (url) {
+		this.cached.delete(url);
+	},
+
+	clear: function () {
+		this.cached.clear();
+	}
+};
+
+
+export class TextureCache
+{
+	constructor() {
+		this.tex_cache = new Map;
+		this.tex_precache = new Map;
+		this.verbose = false;
+	}
+
+	// Besides url, all other args are lambdas and all of them are only called
+	// when Image loading succeeds.
+	// - callback takes 1 arguments: texture
+	// - image_to_texture takes 1 argument: image and returns texture
+	// - when_delayed takes no arguments.
+	// When deliver is called multiple times with the same url while the initial
+	// Image processing is still ongoing, the latter image_to_texture and
+	// when_delay are not stored -- they are assumed to be the same as they
+	// are supposedly coming from the same rendering context.
+
+	deliver(url, callback, image_to_texture, when_delayed)
+	{
+		let tex = this.tex_cache.get(url);
+		if (tex !== undefined) {
+		   if (this.verbose) console.log("TextureCache HAS", url);
+		   if (tex) callback(tex);
+		   return;
+		}
+
+		let pc = this.tex_precache.get(url);
+		if (pc !== undefined) {
+		   if (this.verbose) console.log("TextureCache url is incoming -- appending callback", url);
+		   pc.array.push(callback);
+		   return;
+		}
+
+		this.tex_precache.set(url, { img2tex: image_to_texture,
+			                         delayed: when_delayed,
+									 array: [callback] });
+
+ 	 	ImageCache.deliver(url, this.image_loaded.bind(this));
+	}
+
+	image_loaded(url, image, delayed)
+	{
+		let pc = this.tex_precache.get(url);
+
+		let tex = image ? pc.img2tex(image) : null;
+
+		this.tex_cache.set(url, tex);
+
+		if (tex)
+		{
+		   for (let i = 0; i < pc.array.length; ++i) {
+			  pc.array[i](tex);
+		   }
+		}
+
+		if (tex && delayed)
+		   pc.delayed();
+
+	   this.tex_precache.delete(url);
+	}
+
+	remove(url) {
+		this.tex_cache.delete(url);
+	}
+
+	clear() {
+		this.tex_cache.clear();
+	}
+};

--- a/src/materials/PickingShaderMaterial.js
+++ b/src/materials/PickingShaderMaterial.js
@@ -38,11 +38,13 @@ export class PickingShaderMaterial extends CustomShaderMaterial {
 
 
             if(pickMode === PickingShaderMaterial.PICK_MODE.RGB){
+                this.removeUniform("u_PickInstance");
                 this.rmSBFlag("PICK_MODE_UINT");
                 this.addSBFlag("PICK_MODE_RGB");
             }else if(pickMode === PickingShaderMaterial.PICK_MODE.UINT){
                 this.rmSBFlag("PICK_MODE_RGB");
                 this.addSBFlag("PICK_MODE_UINT");
+                this.setUniform("u_PickInstance", false);
             }else{
                 console.error("Unknown pick mode: [" + pickMode + "].");
             }

--- a/src/materials/ZSpriteBasicMaterial.js
+++ b/src/materials/ZSpriteBasicMaterial.js
@@ -25,6 +25,17 @@ export class ZSpriteBasicMaterial extends CustomShaderMaterial {
         this.diffuse = args.diffuse ? args.diffuse : new Color(Math.random() * 0xffffff);
     }
 
+    clone_for_picking() {
+        let o = new ZSpriteBasicMaterial( {
+            SpriteMode: this.getUniform("SpriteMode"), SpriteSize: this.getUniform("SpriteSize"),
+            color: this.color, emissive: this.emissive, diffuse: this.diffuse
+        } );
+        for (const m of this.maps) o.addMap(m);
+        o.instanceData = this.instanceData;
+        o.addSBFlag('PICK_MODE_UINT');
+        return o;
+    }
+
     clone_for_outline() {
         let o = new ZSpriteBasicMaterial( {
             SpriteMode: this.getUniform("SpriteMode"), SpriteSize: this.getUniform("SpriteSize"),

--- a/src/materials/ZSpriteBasicMaterial.js
+++ b/src/materials/ZSpriteBasicMaterial.js
@@ -32,7 +32,8 @@ export class ZSpriteBasicMaterial extends CustomShaderMaterial {
         } );
         for (const m of this.maps) o.addMap(m);
         o.instanceData = this.instanceData;
-        o.addSBFlag('PICK_MODE_UINT');
+        o.addSBFlag("PICK_MODE_UINT");
+        o.setUniform("u_PickInstance", false);
         return o;
     }
 

--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -252,13 +252,15 @@ export class Mesh extends Object3D {
 		this.modelViewMatrix.multiplyMatrices(camera.matrixWorldInverse, this._matrixWorld);
 		this.normalMatrix.getNormalMatrix(this._modelViewMatrix);
 	}
-	draw(gl, glManager){
+	draw(gl, glManager, instance_count=0){
 		if (this.geometry.drawWireframe) {
 			let buffer = glManager.getAttributeBuffer(this.geometry.wireframeIndices);
 			gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, buffer);
 
 			if(this._instanced || this._instancedTranslation){
-				gl.drawElementsInstanced(gl.LINES, this.geometry.wireframeIndices.count(), gl.UNSIGNED_INT, 0, this._instanceCount);
+				if (!instance_count)
+					instance_count = this._instanceCount;
+				gl.drawElementsInstanced(gl.LINES, this.geometry.wireframeIndices.count(), gl.UNSIGNED_INT, 0, instance_count);
 			}
 			else{
 				gl.drawElements(gl.LINES, this.geometry.wireframeIndices.count(), gl.UNSIGNED_INT, 0);
@@ -270,7 +272,9 @@ export class Mesh extends Object3D {
 			gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, buffer);
 
 			if(this._instanced || this._instancedTranslation){
-				gl.drawElementsInstanced(this.renderingPrimitive, this.geometry.indexCount, gl.UNSIGNED_INT, 4 * this.geometry.indexStart, this._instanceCount);
+				if (!instance_count)
+					instance_count = this._instanceCount;
+				gl.drawElementsInstanced(this.renderingPrimitive, this.geometry.indexCount, gl.UNSIGNED_INT, 4 * this.geometry.indexStart, instance_count);
 			}
 			else{
 				gl.drawElements(this.renderingPrimitive, this.geometry.indexCount, gl.UNSIGNED_INT, 4 * this.geometry.indexStart);
@@ -279,7 +283,9 @@ export class Mesh extends Object3D {
 		else {
 			//non indexed
 			if(this._instanced || this._instancedTranslation){
-				gl.drawArraysInstanced(this.renderingPrimitive, 0, this.geometry.vertices.count(), this._instanceCount);
+				if (!instance_count)
+					instance_count = this._instanceCount;
+				gl.drawArraysInstanced(this.renderingPrimitive, 0, this.geometry.vertices.count(), instance_count);
 			}
 			else{
 				gl.drawArrays(this.renderingPrimitive, 0, this.geometry.vertices.count());

--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -246,7 +246,7 @@ export class Mesh extends Object3D {
 	}
 	update(glManager, camera){
 		// Updates or derives attributes from the WebGL geometry
-		glManager.updateObjectData(this);
+		glManager.updateObjectData(this, this.material);
 
 		// Derive mv and normal matrices
 		this.modelViewMatrix.multiplyMatrices(camera.matrixWorldInverse, this._matrixWorld);

--- a/src/objects/SkyBox2.js
+++ b/src/objects/SkyBox2.js
@@ -25,7 +25,7 @@ export class SkyBox2 extends Cube {
 	}
 	update(glManager, camera){
 		// Updates or derives attributes from the WebGL geometry
-		glManager.updateObjectData(this);
+		glManager.updateObjectData(this, this.material);
 
 		// Derive mv and normal matrices
 		this._modifiedViewMatrix.copy(camera.matrixWorldInverse);

--- a/src/objects/ZSprite.js
+++ b/src/objects/ZSprite.js
@@ -47,14 +47,11 @@ export class ZSprite extends Mesh {
         }
 
         // MT for Sebastien -- what would be the best way to clone material?
-        // ZSpriteBasicMaterial.clone_for_outline() seems OK (but one needs to 
-        // take care with uniform / texture / instanceData updates).
-
-        // let pmat = Object.assign(new ZSpriteBasicMaterial(), material);
-        // pmat.addSBFlag('PICK_MODE_UINT'); // should get it from PickingShaderMaterial
-        let pmat = undefined;
-        // let omat = Object.assign(new ZSpriteBasicMaterial(), material);
-        // omat.addSBFlag('OUTLINE');
+        // ZSpriteBasicMaterial.clone_for_xyzz() seems OK but one needs to
+        // take care with uniform / texture / instanceData updates.
+        // Ideally, one could even have the same program built and compiled
+        // several times with different SB flags.
+        let pmat = material.clone_for_picking();
         let omat = material.clone_for_outline();
 
         //SUPER

--- a/src/renderers/MeshRenderer.js
+++ b/src/renderers/MeshRenderer.js
@@ -72,6 +72,11 @@ export class MeshRenderer extends Renderer {
 		this._pickedID = 0;
 		this._pickedObject3D = null;
 		this._pickCallback = null;
+		//outline
+		this._outlineEnabled = false;
+		this._outlineArray = null;
+
+		// Has rendering actually been done (all programs loaded)
 		this.used = false;
 	}
 
@@ -145,6 +150,12 @@ export class MeshRenderer extends Renderer {
 
 		//RENDER OBJECTS
 
+		// Render outlined objects
+		if (this._outlineEnabled) {
+			this._outlineEnabled = false;
+			this._renderOutline(this._outlineArray, camera);
+			return;
+		}
 		// Render picking objects
 		if(this._pickEnabled) {
 			this._pickEnabled = false;
@@ -266,6 +277,22 @@ export class MeshRenderer extends Renderer {
 
 			this._setup_material_side(object.material.side);
 			this._setup_material_depth(true, object.material.depthFunc, true);
+
+			//COMPACT
+			this._drawObject(object);
+		}
+	}
+	_renderOutline(list, camera){
+		// Only render top-levels
+		for (let i = 0; i < list.length; i++) {
+			const object = list[i];
+
+			let mat = object.outlineMaterial ? object.outlineMaterial : this._defaultOutlineMat;
+
+			this._setupProgram(object, camera, mat);
+
+			this._setup_material_side(mat.side);
+			this._setup_material_depth(true, mat.depthFunc, true);
 
 			//COMPACT
 			this._drawObject(object);

--- a/src/renderers/MeshRenderer.js
+++ b/src/renderers/MeshRenderer.js
@@ -111,32 +111,36 @@ export class MeshRenderer extends Renderer {
 
 		// Programs need to be loaded after the lights
 		if (!this._loadRequiredPrograms()) {
-			console.warn("Required programs not loaded!");
-
-			console.log("-----------------PRE-----------------");
-			console.log("REQUIRED: " + this._requiredPrograms + " length: " + this._requiredPrograms.size);
-			console.log(this._requiredPrograms);
-			console.log("--------------------------------------");
-			console.log("LOADING: " + this._loadingPrograms + " length: " + this._loadingPrograms.size);
-			console.log(this._loadingPrograms);
-			console.log("--------------------------------------");
-			console.log("COMPILED: " + this._compiledPrograms + " length: " + this._compiledPrograms.size);
-			console.log(this._compiledPrograms);
-			console.log("--------------------------------------");
-
+			if (this._logLevel >= 1) {
+				console.warn("Required programs not loaded!");
+			}
+			if (this._logLevel >= 2) {
+				console.log("-----------------PRE-----------------");
+				console.log("REQUIRED: " + this._requiredPrograms + " length: " + this._requiredPrograms.size);
+				console.log(this._requiredPrograms);
+				console.log("--------------------------------------");
+				console.log("LOADING: " + this._loadingPrograms + " length: " + this._loadingPrograms.size);
+				console.log(this._loadingPrograms);
+				console.log("--------------------------------------");
+				console.log("COMPILED: " + this._compiledPrograms + " length: " + this._compiledPrograms.size);
+				console.log(this._compiledPrograms);
+				console.log("--------------------------------------");
+			}
 			return;
 		}
 		if(!this.used) {
-			console.log("-----------------POST------------------");
-			console.log("REQUIRED: " + this._requiredPrograms + " length: " + this._requiredPrograms.size);
-			console.log(this._requiredPrograms);
-			console.log("--------------------------------------");
-			console.log("LOADING: " + this._loadingPrograms + " length: " + this._loadingPrograms.size);
-			console.log(this._loadingPrograms);
-			console.log("--------------------------------------");
-			console.log("COMPILED: " + this._compiledPrograms + " length: " + this._compiledPrograms.size);
-			console.log(this._compiledPrograms);
-			console.log("--------------------------------------");
+			if (this._logLevel >= 2) {
+				console.log("-----------------POST------------------");
+				console.log("REQUIRED: " + this._requiredPrograms + " length: " + this._requiredPrograms.size);
+				console.log(this._requiredPrograms);
+				console.log("--------------------------------------");
+				console.log("LOADING: " + this._loadingPrograms + " length: " + this._loadingPrograms.size);
+				console.log(this._loadingPrograms);
+				console.log("--------------------------------------");
+				console.log("COMPILED: " + this._compiledPrograms + " length: " + this._compiledPrograms.size);
+				console.log(this._compiledPrograms);
+				console.log("--------------------------------------");
+			}
 			this.used = true;
 		}
 

--- a/src/renderers/MeshRenderer.js
+++ b/src/renderers/MeshRenderer.js
@@ -164,7 +164,7 @@ export class MeshRenderer extends Renderer {
 		}
 		if (this._pickSecondaryEnabled) {
 			this._pickSecondaryEnabled = false;
-			if (this._pickedObject3D && this._pickedObject3D.instanced)
+			if (this._pickedObject3D)
 				this.pick_instance(this._pickedObject3D, camera);
 			return;
 		}
@@ -274,10 +274,8 @@ export class MeshRenderer extends Renderer {
 			}
 
 			const mat = object.pickingMaterial;
-			// picking material attribs are not updated in standard Mesh update.
-			if (mat instanceof CustomShaderMaterial) {
-				this._glManager.updateCustomShaderAttributes(mat);
-			}
+			this._glManager.updateObjectData(object, mat);
+
 			this._setupProgram(object, camera, mat);
 
 			this._setup_material_side(mat.side);
@@ -292,10 +290,8 @@ export class MeshRenderer extends Renderer {
 			const object = list[i];
 
 			const mat = object.outlineMaterial ? object.outlineMaterial : this._defaultOutlineMat;
-			// outline material attribs are not updated in standard Mesh update.
-			if (object.outlineMaterial && mat instanceof CustomShaderMaterial) {
-				this._glManager.updateCustomShaderAttributes(mat);
-			}
+			this._glManager.updateObjectData(object, mat);
+
 			this._setupProgram(object, camera, mat);
 
 			this._setup_material_side(mat.side);
@@ -417,7 +413,8 @@ export class MeshRenderer extends Renderer {
 					buffer = this._glManager.getAttributeBuffer(a_Translation);
 					attributeSetter["a_Translation"].set(buffer, 4, object.instanced, a_Translation.divisor);
 				case "gl_InstanceID":
-					// For some reason gl_InstanceID is considered an attribute. Ignore.
+				case "gl_VertexID":
+					// For some reason gl_InstanceID and gl_VertexID are considered attributes. Ignore.
 					break;
 				default:
 					let found = false;

--- a/src/renderers/Renderer.js
+++ b/src/renderers/Renderer.js
@@ -65,6 +65,9 @@ export class Renderer {
 
 		//viewport
 		this._viewport = {x: 0, y: 0, width: this._canvas.width, height: this._canvas.height};
+
+		//logLevel: 0 - error, 1 - warning, 2 - info, 3 - debug
+		this._logLevel = 2;
 	}
 
 	render(scene, camera, renderTarget, cubeTarget = false, side = 0) {
@@ -203,7 +206,8 @@ export class Renderer {
 
 		// Called when the program template is loaded.. Initiates shader compilation
 		let onLoad = function (programTemplateSrc) {
-			console.log("(Down)loaded: " + program.programID + ": " + programName + '.');
+			if (scope._logLevel >= 2)
+				console.log("(Down)loaded: " + program.programID + ": " + programName + '.');
 			scope._glProgramManager.addTemplate(programTemplateSrc);
 			scope._loadingPrograms.delete(program.programID);
 		};
@@ -216,7 +220,8 @@ export class Renderer {
 
 		// Check if the program is already loading
 		if (!this._loadingPrograms.has(program.programID)) {
-			console.log("(Down)loading: " + program.programID + ": " + programName + '.');
+			if (this._logLevel >= 2)
+				console.log("(Down)loading: " + program.programID + ": " + programName + '.');
 			this._loadingPrograms.set(program.programID, program);
 
 			// Initiate loading

--- a/src/shaders/basic/basic_zsprite_template.frag
+++ b/src/shaders/basic/basic_zsprite_template.frag
@@ -166,52 +166,37 @@ void main() {
         #end
         #if (TRANSPARENT)
             if (color.w <= 0.00392) discard;
-            // alternatively, increase fragment depth?
-            // if (texcol.w < 0.25) gl_FragDepth = some larger value, clamped to 1.0; else gl_FragDepth = gl_FragCoord.z;
         #fi
     #fi
 
-  if (color.w > 0.50) {
-
-    #if (PICK_MODE_RGB)
-        objectID = vec4(u_RGB_ID, 1.0);
-    #else if (PICK_MODE_UINT)
-        #if (PICK_INSTANCE)
-            objectID = uint(gl_InstanceID) + 1; // no +1 if we do white clear
-        #else
-            objectID = u_UINT_ID;
-        #fi
-    #else if (OUTLINE)
-        vn_viewspace = vec4(v_normal_viewspace, 0.0);
-        vd_viewspace = vec4(v_ViewDirection_viewspace, 0.0);
-        #if (DEPTH)
-            de_viewspace = vec4(gl_FragCoord.z, 0.0, 0.0, 1.0);
-        #fi
+    // Special handling for outline to provide better edge detection,
+    // especially with overlapping outlined objects.
+    #if (OUTLINE)
+        if (color.w > 0.50) {
+            vn_viewspace = vec4(v_normal_viewspace, 0.0);
+            vd_viewspace = vec4(v_ViewDirection_viewspace, 0.0);
+            #if (DEPTH)
+                de_viewspace = vec4(gl_FragCoord.z, 0.0, 0.0, 1.0);
+            #fi
+        } else {
+            gl_FragDepth = 1.0;
+            vn_viewspace = vec4(0.0, 0.0, 0.0, 0.0);
+            vd_viewspace = vec4(0.0, 0.0, 0.0, 0.0);
+            #if (DEPTH)
+                de_viewspace = vec4(1.0, 0.0, 0.0, 1.0);
+            #fi
+        }
     #else
-        outColor = color;
-    #fi
-
-  } else {
-
-    #if (PICK_MODE_RGB)
-        objectID = vec4(0.0, 0.0, 0.0, 1.0);
-    #else if (PICK_MODE_UINT)
-        #if (PICK_INSTANCE)
-            objectID = 0; // no +1 if we do white clear
+        #if (PICK_MODE_RGB)
+            objectID = vec4(u_RGB_ID, 1.0);
+        #else if (PICK_MODE_UINT)
+            #if (PICK_INSTANCE)
+                objectID = uint(gl_InstanceID); // 0 is a valid result
+            #else
+                objectID = u_UINT_ID;
+            #fi
         #else
-            objectID = 0;
+            outColor = color;
         #fi
-    #else if (OUTLINE)
-        gl_FragDepth = 1.0;
-        vn_viewspace = vec4(0.0, 0.0, 0.0, 0.0);
-        vd_viewspace = vec4(0.0, 0.0, 0.0, 0.0);
-        #if (DEPTH)
-            de_viewspace = vec4(1.0, 0.0, 0.0, 1.0);
-        #fi
-    #else
-        outColor = color;
     #fi
-
-  }
-
 }

--- a/src/shaders/basic/basic_zsprite_template.frag
+++ b/src/shaders/basic/basic_zsprite_template.frag
@@ -76,6 +76,10 @@ in vec3 fragVPos;
     layout(location = 0) out vec4 objectID;
 #else if (PICK_MODE_UINT)
     uniform uint u_UINT_ID;
+    #if (INSTANCED)
+        uniform bool u_PickInstance;
+        flat in uint InstanceID;
+    #fi
     layout(location = 0) out uint objectID;
 #else if (OUTLINE)
     // in vec3 v_position_viewspace;
@@ -190,8 +194,12 @@ void main() {
         #if (PICK_MODE_RGB)
             objectID = vec4(u_RGB_ID, 1.0);
         #else if (PICK_MODE_UINT)
-            #if (PICK_INSTANCE)
-                objectID = uint(gl_InstanceID); // 0 is a valid result
+            #if (INSTANCED)
+                if (u_PickInstance) {
+                    objectID = InstanceID; // 0 is a valid result
+                } else {
+                    objectID = u_UINT_ID;
+                }
             #else
                 objectID = u_UINT_ID;
             #fi

--- a/src/shaders/basic/basic_zsprite_template.vert
+++ b/src/shaders/basic/basic_zsprite_template.vert
@@ -61,11 +61,15 @@ in vec3 VPos;       // Vertex position
     #if (PICK_MODE_UINT)
         flat out uint InstanceID;
     #fi
+    #if (OUTLINE)
+        uniform bool u_OutlineGivenInstances;
+        in  int  a_OutlineInstances;
+    #fi
 #fi
 
 #if (OUTLINE)
-out vec3 v_normal_viewspace;
-out vec3 v_ViewDirection_viewspace;
+    out vec3 v_normal_viewspace;
+    out vec3 v_ViewDirection_viewspace;
 #fi
 
 //MAIN
@@ -75,8 +79,13 @@ void main() {
     vec4 VPos_viewspace;
 
     #if (INSTANCED)
+        int iID = gl_InstanceID;
+        #if (OUTLINE)
+            if (u_OutlineGivenInstances)
+                iID = a_OutlineInstances;
+        #fi
         int   tsx = textureSize(material.instanceData, 0).x;
-        ivec2 tc  = ivec2(gl_InstanceID % tsx, gl_InstanceID / tsx);
+        ivec2 tc  = ivec2(iID % tsx, iID / tsx);
         vec4  pos = texelFetch(material.instanceData, tc, 0);
         // see also texelFetchOffset about how to get neigboring texels
 
@@ -125,6 +134,6 @@ void main() {
     #fi
 
     #if (INSTANCED && PICK_MODE_UINT)
-        InstanceID = uint(gl_InstanceID);
+        InstanceID = uint(iID);
     #fi
  }

--- a/src/shaders/basic/basic_zsprite_template.vert
+++ b/src/shaders/basic/basic_zsprite_template.vert
@@ -58,6 +58,9 @@ in vec3 VPos;       // Vertex position
 
 #if (INSTANCED)
     uniform Material material;
+    #if (PICK_MODE_UINT)
+        flat out uint InstanceID;
+    #fi
 #fi
 
 #if (OUTLINE)
@@ -119,5 +122,9 @@ void main() {
 
         float dToCam = length(VPos_viewspace.xyz);
         v_ViewDirection_viewspace = -VPos_viewspace.xyz / dToCam;
+    #fi
+
+    #if (INSTANCED && PICK_MODE_UINT)
+        InstanceID = uint(gl_InstanceID);
     #fi
  }

--- a/src/shaders/picker/picker_TRIANGLES.frag
+++ b/src/shaders/picker/picker_TRIANGLES.frag
@@ -16,6 +16,8 @@ layout(location = 0) out vec4 objectID;
 #fi
 #if(PICK_MODE_UINT)
 layout(location = 0) out uint objectID;
+uniform bool u_PickInstance;
+flat in uint InstanceID;
 #fi
 
 
@@ -26,6 +28,9 @@ void main() {
     objectID = vec4(u_RGB_ID, 1.0);
     #fi
     #if(PICK_MODE_UINT)
-    objectID = u_UINT_ID;
+    if (u_PickInstance)
+        objectID = InstanceID;
+    else
+        objectID = u_UINT_ID;
     #fi
 }

--- a/src/shaders/picker/picker_TRIANGLES.vert
+++ b/src/shaders/picker/picker_TRIANGLES.vert
@@ -1,23 +1,20 @@
 #version 300 es
 precision mediump float;
 
-
 //UIO
 //**********************************************************************************************************************
-#if (INSTANCED)
-//uniform mat4 VMat;
-uniform mat4 MVMat;
-#fi
-#if (!INSTANCED)
 uniform mat4 MVMat; // Model View Matrix
-#fi
 uniform mat4 PMat;  // Projection Matrix
 
 #if (INSTANCED)
 in mat4 MMat;
 #fi
+
 in vec3 VPos;       // Vertex position
 
+#if (PICK_MODE_UINT)
+flat out uint InstanceID;
+#fi
 
 //MAIN
 //**********************************************************************************************************************
@@ -30,5 +27,13 @@ void main() {
     #if (INSTANCED)
     //gl_Position = PMat * VMat * MMat * vec4(VPos, 1.0);
     gl_Position = PMat * MVMat * MMat * vec4(VPos, 1.0);
+    #fi
+
+    #if (PICK_MODE_UINT)
+        #if (INSTACED)
+            InstanceID = uint(gl_InstanceID);
+        #else
+            InstanceID = uint(gl_VertexID);
+        #fi
     #fi
 }

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -36,6 +36,10 @@ export class Texture {
 		this._width = width;
 		this._height = height;
 
+		// Set UNPACK_FLIP_Y_WEBGL - this is needed for Image data source.
+		// Set it to false when loading data from raw arrays where first data is at (0,0).
+		this._flipy = true;
+
 		this._dirty = true;
 	}
 
@@ -81,6 +85,9 @@ export class Texture {
 	}
 	get height() {
 		return this._height;
+	}
+	get flipy() {
+		return this._flipy;
 	}
 	// endregion
 
@@ -141,6 +148,13 @@ export class Texture {
 	set height(value) {
 		if (value !== this._height) {
 			this._height = value;
+			this._dirty = true;
+		}
+	}
+
+	set flipy(value) {
+		if (value !== this._flipy) {
+			this._flipy = value;
 			this._dirty = true;
 		}
 	}


### PR DESCRIPTION
- Implement two-level Image/TextureCache supporting concurrent loading of the same image multiple times, potentially from several different render contexts.
- Cleanup / separate picking and outline specializations in MeshRenderer.
- Support specific instance outlining in ZSprite (via vertex-attrib).
