### PR TITLE
REve outline/blur integration and initial work on ZLine

### DIFF
--- a/examples/outlineExample/main-ZSprite.js
+++ b/examples/outlineExample/main-ZSprite.js
@@ -1,7 +1,6 @@
 /** IMPORTS */
 import * as RC from "../../src/RenderCore.js";
 
-
 const predef_width = document.body.clientWidth;
 const predef_height = document.body.clientHeight;
 const nearPlane = 0.1;
@@ -118,6 +117,15 @@ const CoreControl = {
             // RC.Texture.LinearFilter, RC.Texture.LinearFilter,
             RC.Texture.LUMINANCE_ALPHA, RC.Texture.LUMINANCE_ALPHA, RC.Texture.UNSIGNED_BYTE,
             2, 2);
+
+        // Testing index array for ZLine prototype (using points from insta points)
+        let la = new Int32Array([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]);
+        this.tex_line_test = new RC.Texture(la, RC.Texture.ClampToEdgeWrapping, RC.Texture.ClampToEdgeWrapping,
+            RC.Texture.NearestFilter, RC.Texture.NearestFilter,
+            RC.Texture.R32I, RC.Texture.RED_INTEGER, RC.Texture.INT,
+            8, 2);
+        this.tex_line_test.flipy = false;
+        this.tex_line_num = 16;
     },
 
     /** INIT CORE */
@@ -256,9 +264,10 @@ const CoreControl = {
                                                 emissive: new RC.Color(0, 1, 0),
                                                 diffuse: new RC.Color(0, 0, 0) } );
         sm.transparent = true;
+        sm.opacity = 0.5;
         // sm.depthWrite = false;
         sm.addMap(this.texDot);
-        sm.instanceData = this.tex_insta_pos;
+        sm.addInstanceData(this.tex_insta_pos);
 
         let sprite = new RC.ZSprite(null, sm);
         sprite.position.set(0, 0, -12.8);
@@ -305,6 +314,27 @@ const CoreControl = {
         sprite4.position.set(-5, 5, 5);
         sprite4.drawOutline = true;
         scene.add(sprite4);
+
+        let lm1 = new RC.ZSpriteBasicMaterial( { SpriteMode: RC.SPRITE_SPACE_WORLD,
+                                                 SpriteSize: [8, 8],
+                                                 color: new RC.Color(1, 0, 0),
+                                                 emissive: new RC.Color(0.2, 0, 0.2),
+                                                 diffuse: new RC.Color(0, 0, 1) } );
+        lm1.addInstanceData(this.tex_insta_pos);
+        lm1.addInstanceData(this.tex_line_test);
+        lm1.programName = "basic_zline";
+        // lm1.side: RC.FRONT_AND_BACK_SIDE;
+        // lm1.transparent = true;
+        lm1.setUniform("u_OffsetSegs", 3);
+        // lm1.setUniform("u_OffsetLineInfo", 999); // not used
+        let xy0 = new RC.Vector2(0,  0.5);
+        let xy1 = new RC.Vector2(1, -0.5);
+        let line1 = new RC.ZSprite(RC.Quad.makeGeometry(xy0, xy1, false, false, false), lm1);
+        line1.frustumCulled = false; // need a way to speciy bounding box/sphere !!!
+        line1.instanced = true;
+        line1.instanceCount = this.tex_line_num;
+        line1.position.set(0, 0, -12.8);
+        scene.add(line1);
 
         //outlined objects
         const cube_outlined = new RC.Cube(2, new RC.Color().setColorName("purple"));

--- a/src/core/GLManager.js
+++ b/src/core/GLManager.js
@@ -354,30 +354,31 @@ export class GLManager {
 	clearSeparate(renderTarget){
 		const drawBuffersLength = renderTarget.sizeDrawBuffers();
 
-
+		this._gl.depthMask(true);
 		//console.warn(renderTarget.depthTexture);
 		//this._gl.clearBufferfi(this._gl.DEPTH_STENCIL, 0, 1.0, 0);
 		this._gl.clearBufferfv(this._gl.DEPTH, 0, new Float32Array([1.0, 1.0, 1.0, 1.0]));
-		
 
 		//const cc = [0, 0, 0, 0];
 		const cc = this._clearColor.toArray();
-		for (let i = 0; i < drawBuffersLength; i++) {
+		for (let idx = 0; idx < drawBuffersLength; idx++) {
 			///console.warn(renderTarget._drawBuffers[i]);
-			const clearIndex = i;
-			
-			if(renderTarget._drawBuffers[i].clearFunction === 0){
-				//console.warn("No clear.");
+			const tex = renderTarget._drawBuffers[idx];
+
+			if (tex.clearColorArray === null)
 				continue;
-			}else if(renderTarget._drawBuffers[i].clearFunction === 1){
-				this._gl.clearBufferuiv(this._gl.COLOR, clearIndex, new Uint32Array(cc));
-			}else if(renderTarget._drawBuffers[i].clearFunction === 2){
-				this._gl.clearBufferiv(this._gl.COLOR, clearIndex, new Int32Array(cc));
-			}else if(renderTarget._drawBuffers[i].clearFunction === 3){
-				this._gl.clearBufferfv(this._gl.COLOR, clearIndex, new Float32Array(cc));
+
+			if(tex.clearFunction === 1){
+				let cca = tex.clearColorArray ? tex.clearColorArray : new Uint32Array(cc);
+				this._gl.clearBufferuiv(this._gl.COLOR, idx, cca);
+			}else if(tex.clearFunction === 2){
+				let cca = tex.clearColorArray ? tex.clearColorArray : new Int32Array(cc);
+				this._gl.clearBufferiv(this._gl.COLOR, idx, cca);
+			}else if(tex.clearFunction === 3){
+				let cca = tex.clearColorArray ? tex.clearColorArray : new Float32Array(cc);
+				this._gl.clearBufferfv(this._gl.COLOR, idx, cca);
 			}else{
-				//console.warn(renderTarget._drawBuffers[i].clearFunction);
-				this._gl.clearBufferfv(this._gl.COLOR, clearIndex, new Float32Array(cc));
+				console.error("Unsupported value for clearFunction", renderTarget._drawBuffers[i].clearFunction);
 			}
 		}
 	}

--- a/src/core/GLManager.js
+++ b/src/core/GLManager.js
@@ -144,7 +144,6 @@ export class GLManager {
 
 		// Update textures
 		let textures = material.maps;
-
 		for (let i = 0; i < textures.length; i++) {
 			this._textureManager.updateTexture(textures[i], false);
 		}
@@ -169,7 +168,9 @@ export class GLManager {
 		if (heightMap) this._textureManager.updateTexture(heightMap, false);
 
 		const instanceData = material.instanceData;
-		if (instanceData) this._textureManager.updateTexture(instanceData, false);
+		for (let i = 0; i < instanceData.length; i++) {
+			this._textureManager.updateTexture(instanceData[i], false);
+		}
 
 		
 		// // CustomShaderMaterial may specify extra attributes

--- a/src/core/GLTextureManager.js
+++ b/src/core/GLTextureManager.js
@@ -66,7 +66,9 @@ export class GLTextureManager {
 
 		this._gl.bindTexture(this._gl.TEXTURE_2D, glTexture);
 
-		this._gl.pixelStorei(this._gl.UNPACK_FLIP_Y_WEBGL, texture.flipy);
+		if (texture.flipy) {
+			this._gl.pixelStorei(this._gl.UNPACK_FLIP_Y_WEBGL, true);
+		}
 
 		// Parse texture data
 		let internalFormat = this._formatToGL(texture._internalFormat);
@@ -110,6 +112,10 @@ export class GLTextureManager {
 		// Generate mipmaps
 		if (texture._generateMipmaps) {
 				this._gl.generateMipmap(this._gl.TEXTURE_2D);
+		}
+
+		if (texture.flipy) {
+			this._gl.pixelStorei(this._gl.UNPACK_FLIP_Y_WEBGL, false);
 		}
 
 		this._gl.bindTexture(this._gl.TEXTURE_2D, null);
@@ -413,6 +419,9 @@ export class GLTextureManager {
 				break;
 			case Texture.UNSIGNED_INT:
 				return this._gl.UNSIGNED_INT;
+				break;
+			case Texture.INT:
+				return this._gl.INT;
 				break;
 			case Texture.FLOAT:
 				return this._gl.FLOAT;

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -59,7 +59,7 @@ export class Material {
 		this._specularMap = null;
 		this._normalMap = null;
 		this._heightMap = null;
-		this._instanceData = null;
+		this._instanceData = [];
 
 		this._normalFlat = false;
 
@@ -491,11 +491,11 @@ export class Material {
 
 		this._heightMap = heightMap;
 	}
-	set instanceData(instanceData){
+	addInstanceData(instanceDatum){
 		// Invalidate required program template
 		this._requiredProgramTemplate = null;
 
-		this._instanceData = instanceData;
+		this._instanceData.push(instanceDatum);
 	}
 
 	/**

--- a/src/materials/ZSpriteBasicMaterial.js
+++ b/src/materials/ZSpriteBasicMaterial.js
@@ -32,7 +32,7 @@ export class ZSpriteBasicMaterial extends CustomShaderMaterial
             color: this.color, emissive: this.emissive, diffuse: this.diffuse
         } );
         for (const m of this.maps) o.addMap(m);
-        o.instanceData = this.instanceData;
+        o._instanceData = this._instanceData;
         o.addSBFlag("PICK_MODE_UINT");
         o.setUniform("u_PickInstance", false);
         return o;
@@ -44,7 +44,7 @@ export class ZSpriteBasicMaterial extends CustomShaderMaterial
             color: this.color, emissive: this.emissive, diffuse: this.diffuse
         } );
         for (const m of this.maps) o.addMap(m);
-        o.instanceData = this.instanceData;
+        o._instanceData = this._instanceData;
         o.addSBFlag('OUTLINE');
         o.setUniform("u_OutlineGivenInstances", false);
         o.setAttribute("a_OutlineInstances", Int32Attribute([0], 1, 0x7fffffff));

--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -158,8 +158,10 @@ export class Mesh extends Object3D {
 	}
 	set pickable(pickable) {
 		super.pickable = pickable;
-		if (pickable && ! this._pickingMaterial)
+		if (pickable && ! this._pickingMaterial) {
 			this.pickingMaterial = new PickingShaderMaterial("TRIANGLES");
+			this.pickingMaterial.side = this.material.side;
+		}
 	}
 	set instanced(instanced) {
 		this._instanced = instanced;

--- a/src/renderers/MeshRenderer.js
+++ b/src/renderers/MeshRenderer.js
@@ -289,7 +289,9 @@ export class MeshRenderer extends Renderer {
 		for (let i = 0; i < list.length; i++) {
 			const object = list[i];
 
-			const mat = object.outlineMaterial ? object.outlineMaterial : this._defaultOutlineMat;
+			const mat = object.outlineMaterial ? object.outlineMaterial :
+						  (object.material.normalFlat ? this._defaultOutlineMatFlat : this._defaultOutlineMat);
+
 			this._glManager.updateObjectData(object, mat);
 
 			this._setupProgram(object, camera, mat);

--- a/src/renderers/MeshRenderer.js
+++ b/src/renderers/MeshRenderer.js
@@ -652,10 +652,10 @@ export class MeshRenderer extends Renderer {
 		}
 
 		const instanceData = material.instanceData;
-		if(instanceData) {
-			const texture = "material.instanceData";
+		for (let i = 0; i < instanceData.length; i++) {
+			const texture = "material.instanceData" + i;
 			if (uniformSetter[texture] !== undefined) {
-				uniformSetter[texture].set(this._glManager.getTexture(instanceData), 4);
+				uniformSetter[texture].set(this._glManager.getTexture(instanceData[i]), 10+i);
 			}else{
 				// console.warn("---------------------------------------------------");
 				// console.warn(object);

--- a/src/renderers/RenderPass.js
+++ b/src/renderers/RenderPass.js
@@ -163,8 +163,9 @@ RenderPass.DEFAULT_R32I_TEXTURE_CONFIG = {
 	minFilter: Texture.LinearFilter,
 	magFilter: Texture.LinearFilter,
 	internalFormat: Texture.R32I,
-	format: Texture.RED,
-	type: Texture.INT
+	format: Texture.RED_INTEGER,
+	type: Texture.INT,
+	clearFunction: 2
 };
 RenderPass.DEFAULT_R32UI_TEXTURE_CONFIG = {
 	wrapS: Texture.ClampToEdgeWrapping,
@@ -183,7 +184,8 @@ RenderPass.DEFAULT_RGB_TEXTURE_CONFIG = {
 	magFilter: Texture.LinearFilter,
 	internalFormat: Texture.RGB,
 	format: Texture.RGB,
-	type: Texture.UNSIGNED_BYTE
+	type: Texture.UNSIGNED_BYTE,
+	clearFunction: 3
 };
 
 RenderPass.DEFAULT_RGBA_TEXTURE_CONFIG = {
@@ -194,7 +196,7 @@ RenderPass.DEFAULT_RGBA_TEXTURE_CONFIG = {
 	internalFormat: Texture.RGBA,
 	format: Texture.RGBA,
 	type: Texture.UNSIGNED_BYTE,
-	clearFunction: 128
+	clearFunction: 3
 };
 
 RenderPass.DEFAULT_RGBA_NEAREST_TEXTURE_CONFIG = {
@@ -204,7 +206,8 @@ RenderPass.DEFAULT_RGBA_NEAREST_TEXTURE_CONFIG = {
 	magFilter: Texture.NearestFilter,
 	internalFormat: Texture.RGBA,
 	format: Texture.RGBA,
-	type: Texture.UNSIGNED_BYTE
+	type: Texture.UNSIGNED_BYTE,
+	clearFunction: 3
 };
 
 
@@ -216,7 +219,8 @@ RenderPass.DEFAULT_R16F_TEXTURE_CONFIG = {
 	magFilter: Texture.LinearFilter,
 	internalFormat: Texture.R16F,
 	format: Texture.RED,
-	type: Texture.HALF_FLOAT
+	type: Texture.HALF_FLOAT,
+	clearFunction: 3
 };
 RenderPass.DEFAULT_R16F_TEXTURE_CUBE_MAP_CONFIG = {
 	wrapS: Texture.ClampToEdgeWrapping,
@@ -227,7 +231,7 @@ RenderPass.DEFAULT_R16F_TEXTURE_CUBE_MAP_CONFIG = {
 	internalFormat: Texture.R16F,
 	format: Texture.RED,
 	type: Texture.HALF_FLOAT,
-	clearFunction: 128
+	clearFunction: 3
 };
 RenderPass.NEAREST_R16F_TEXTURE_CUBE_MAP_CONFIG = {
 	wrapS: Texture.ClampToEdgeWrapping,
@@ -238,7 +242,7 @@ RenderPass.NEAREST_R16F_TEXTURE_CUBE_MAP_CONFIG = {
 	internalFormat: Texture.R16F,
 	format: Texture.RED,
 	type: Texture.HALF_FLOAT,
-	clearFunction: 128
+	clearFunction: 3
 };
 RenderPass.DEFAULT_RGB16F_TEXTURE_CONFIG = {
 	wrapS: Texture.ClampToEdgeWrapping,
@@ -247,7 +251,8 @@ RenderPass.DEFAULT_RGB16F_TEXTURE_CONFIG = {
 	magFilter: Texture.LinearFilter,
 	internalFormat: Texture.RGB16F,
 	format: Texture.RGBA,
-	type: Texture.HALF_FLOAT
+	type: Texture.HALF_FLOAT,
+	clearFunction: 3
 };
 RenderPass.DEFAULT_RGBA16F_TEXTURE_CONFIG = {
 	wrapS: Texture.ClampToEdgeWrapping,
@@ -257,7 +262,7 @@ RenderPass.DEFAULT_RGBA16F_TEXTURE_CONFIG = {
 	internalFormat: Texture.RGBA16F,
 	format: Texture.RGBA,
 	type: Texture.HALF_FLOAT,
-	clearFunction: 128
+	clearFunction: 3
 };
 RenderPass.NEAREST_RGBA16F_TEXTURE_CONFIG = {
 	wrapS: Texture.ClampToEdgeWrapping,
@@ -267,7 +272,7 @@ RenderPass.NEAREST_RGBA16F_TEXTURE_CONFIG = {
 	internalFormat: Texture.RGBA16F,
 	format: Texture.RGBA,
 	type: Texture.HALF_FLOAT,
-	clearFunction: 128
+	clearFunction: 3
 };
 
 RenderPass.FLOAT_RGB_TEXTURE_CONFIG = {
@@ -277,7 +282,8 @@ RenderPass.FLOAT_RGB_TEXTURE_CONFIG = {
 	magFilter: Texture.LinearFilter,
 	internalFormat: Texture.RGBA16F,
 	format: Texture.RGBA,
-	type: Texture.HALF_FLOAT
+	type: Texture.HALF_FLOAT,
+	clearFunction: 3
 };
 
 RenderPass.FULL_FLOAT_RGB_TEXTURE_CONFIG = {
@@ -287,7 +293,8 @@ RenderPass.FULL_FLOAT_RGB_TEXTURE_CONFIG = {
 	magFilter: Texture.LinearFilter,
 	internalFormat: Texture.RGBA16F,
 	format: Texture.RGBA,
-	type: Texture.FLOAT
+	type: Texture.FLOAT,
+	clearFunction: 3
 };
 
 RenderPass.FULL_FLOAT_RGB_NEAREST_TEXTURE_CONFIG = {
@@ -297,7 +304,8 @@ RenderPass.FULL_FLOAT_RGB_NEAREST_TEXTURE_CONFIG = {
 	magFilter: Texture.NearestFilter,
 	internalFormat: Texture.RGBA16F,
 	format: Texture.RGBA,
-	type: Texture.FLOAT
+	type: Texture.FLOAT,
+	clearFunction: 3
 };
 
 //32F
@@ -308,5 +316,6 @@ RenderPass.FULL_FLOAT_R32F_TEXTURE_CONFIG = {
 	magFilter: Texture.LinearFilter,
 	internalFormat: Texture.R32F,
 	format: Texture.RED,
-	type: Texture.FLOAT
+	type: Texture.FLOAT,
+	clearFunction: 3
 };

--- a/src/renderers/RenderQueue.js
+++ b/src/renderers/RenderQueue.js
@@ -99,7 +99,7 @@ export class RenderQueue {
 				cachedTexture.width = viewportRP.width;
 				cachedTexture.height = viewportRP.height;
 
-				// Add texture ass draw buffer to render target
+				// Add texture as draw buffer to render target
 				this._renderTarget.addDrawBuffer(cachedTexture);
 			}
 			else {
@@ -132,10 +132,21 @@ export class RenderQueue {
 						viewportRP.height
 					);
 				}
+				texture.clearFunction = texConfig.clearFunction;
 
 				this._renderTarget.addDrawBuffer(texture);
 				// Bind depth texture to the given ID ID
 				this._textureMap[texID] = texture;
+
+				cachedTexture = texture;
+			}
+			// If clearColorArray is null, buffer will not be cleared without warning.
+			// clearColorArray, when set, should be appropriate 4-element native array for the buffer format.
+			// When clear color is not set, the buffer will be cleared with renderer's clear color.
+			if (texTemplate.clearColorArray !== undefined) {
+				cachedTexture.clearColorArray = texTemplate.clearColorArray;
+			} else {
+				delete cachedTexture.clearColorArray;
 			}
 		}
 	}
@@ -150,10 +161,10 @@ export class RenderQueue {
 	}
 
 	render_pass_idx(i) {
-		this.render_pass(this._renderQueue[i]);
+		this.render_pass(this._renderQueue[i], i);
 	}
 
-	render_pass(renderPass) {
+	render_pass(renderPass, i) {
 		// Check if the render pass is initialized
 		if (!renderPass._isInitialized) {
 			renderPass._initialize(this._textureMap, this._forwardedAdditionalData);
@@ -319,7 +330,7 @@ export class RenderQueue {
 		this.render_begin();
 
 		for (let i = 0; i < this._renderQueue.length; i++) {
-			this.render_pass(this._renderQueue[i]);
+			this.render_pass(this._renderQueue[i], i);
 		}
 
 		return this.render_end();

--- a/src/renderers/RenderQueue.js
+++ b/src/renderers/RenderQueue.js
@@ -140,170 +140,189 @@ export class RenderQueue {
 		}
 	}
 
-	render() {
+	render_begin() {
+		if (this._saved_vp) {
+			console.error("RenderQueue.render_begin called without an intervening end.");
+			return;
+		}
 		// Store current renderer viewport
-		let cleanupViewport = this._renderer.getViewport();
+		this._saved_vp = this._renderer.getViewport();
+	}
 
-		for (let i = 0; i < this._renderQueue.length; i++) {
-			let renderPass = this._renderQueue[i];
+	render_pass_idx(i) {
+		this.render_pass(this._renderQueue[i]);
+	}
 
-			// Check if the render pass is initialized
-			if (!renderPass._isInitialized) {
-				renderPass._initialize(this._textureMap, this._forwardedAdditionalData);
-				renderPass._isInitialized = true;
-			}
+	render_pass(renderPass) {
+		// Check if the render pass is initialized
+		if (!renderPass._isInitialized) {
+			renderPass._initialize(this._textureMap, this._forwardedAdditionalData);
+			renderPass._isInitialized = true;
+		}
 
-			let viewportRP = renderPass.viewport;
+		let viewportRP = renderPass.viewport;
 
-			// Execute preprocess step
-			let preprocOutput = renderPass.preprocess(this._textureMap, this._forwardedAdditionalData);
+		// Execute preprocess step
+		let preprocOutput = renderPass.preprocess(this._textureMap, this._forwardedAdditionalData);
 
-			// If prepossessing step outputs null skip this render pass.
-			if (preprocOutput === null) {
-				continue;
-			}
+		// If prepossessing step outputs null skip this render pass.
+		if (preprocOutput === null) {
+			return;
+		}
 
-			// Determine the render pass type
-			if (renderPass.type === RenderPass.BASIC) {
-				// This is a BASIC scene rendering render pass
+		// Determine the render pass type
+		if (renderPass.type === RenderPass.BASIC) {
+			// This is a BASIC scene rendering render pass
 
-				// Validate preprocess output
-				if (preprocOutput.scene === undefined || !(preprocOutput.scene instanceof Scene) ||
-					preprocOutput.camera === undefined || !(preprocOutput.camera instanceof Camera)) {
-					console.error("Render pass " + i + " has invalid preprocess output!");
-					return;
-				}
-
-				// Render to specified target
-				if (renderPass.target === RenderPass.SCREEN) {
-					// RENDER TO SCREEN
-					// Set requested viewport
-					this._renderer.updateViewport(viewportRP.width, viewportRP.height);
-
-					// Render to screen
-					this._renderer.render(preprocOutput.scene, preprocOutput.camera);
-				}
-				else if (renderPass.target === RenderPass.TEXTURE) {
-					// RENDER TO TEXTURE
-					// Setup render target as the render pass specifies
-					this._setupRenderTarget(renderPass);
-
-					// Render to render target
-					this._renderer.render(preprocOutput.scene, preprocOutput.camera, this._renderTarget)
-				}
-				else if (renderPass.target === RenderPass.TEXTURE_CUBE_MAP) {
-					// RENDER TO TEXTURE_CUBE_MAP
-					// Setup render target as the render pass specifies
-					this._setupRenderTarget(renderPass);
-
-					// Render to render target
-					this._renderer.render(preprocOutput.scene, preprocOutput.camera, this._renderTarget, true, renderPass.side);
-				}
-				else {
-					console.error("Unknown render pass " + i + " target.");
-					return;
-				}
-			}
-			else if (renderPass.type === RenderPass.TEXTURE_MERGE) {
-				// This is a texture merging render pass
-
-				// Validate preprocess output
-				if (preprocOutput.material === undefined || !(preprocOutput.material instanceof CustomShaderMaterial) ||
-					preprocOutput.textures === undefined || !Array.isArray(preprocOutput.textures)) {
-					console.error("Render pass " + i + " has invalid preprocess output!");
-					return;
-				}
-
-				// Remove possible previous maps
-				preprocOutput.material.clearMaps();
-
-				// Add textures to material
-				for (let i = 0; i < preprocOutput.textures.length; i++) {
-					preprocOutput.material.addMap(preprocOutput.textures[i]);
-				}
-
-				// Set quad material so that the correct shader will be used
-				this._textureMergeQuad.material = preprocOutput.material;
-
-				// Render to specified target
-				if (renderPass.target === RenderPass.SCREEN) {
-					// RENDER TO SCREEN
-					// Set requested viewport
-					this._renderer.updateViewport(viewportRP.width, viewportRP.height);
-
-					// Render to screen
-					this._renderer.render(this._textureMergeScene, this._textureMergeCamera);
-				}
-				else if (renderPass.target === RenderPass.TEXTURE) {
-					// RENDER TO TEXTURE
-					// Setup render target as the render pass specifies
-					this._setupRenderTarget(renderPass);
-
-					// Render to render target
-					this._renderer.render(this._textureMergeScene, this._textureMergeCamera, this._renderTarget);
-				}
-				else {
-					console.error("Unknown render pass " + i + " target.");
-					return;
-				}
-			}
-			else if (renderPass.type === RenderPass.POSTPROCESS) {
-				// This is a texture merging render pass
-
-				// Validate preprocess output
-				if (preprocOutput.material === undefined || !(preprocOutput.material instanceof CustomShaderMaterial) ||
-					preprocOutput.textures === undefined || !Array.isArray(preprocOutput.textures)) {
-					console.error("Render pass " + i + " has invalid preprocess output!");
-					return;
-				}
-
-				// Remove possible previous maps
-				preprocOutput.material.clearMaps();
-
-				// Add textures to material
-				for (let i = 0; i < preprocOutput.textures.length; i++) {
-					preprocOutput.material.addMap(preprocOutput.textures[i]);
-				}
-
-				// Set quad material so that the correct shader will be used
-				this._textureMergeQuad.material = preprocOutput.material;
-
-				// Render to specified target
-				if (renderPass.target === RenderPass.SCREEN) {
-					// RENDER TO SCREEN
-					// Set requested viewport
-					this._renderer.updateViewport(viewportRP.width, viewportRP.height);
-
-					// Render to screen
-					this._renderer.render(this._textureMergeScene, this._textureMergeCamera);
-				}
-				else if (renderPass.target === RenderPass.TEXTURE) {
-					// RENDER TO TEXTURE
-					// Setup render target as the render pass specifies
-					this._setupRenderTarget(renderPass);
-
-					// Render to render target
-					this._renderer.render(this._textureMergeScene, this._textureMergeCamera, this._renderTarget);
-				}
-				else {
-					console.error("Unknown render pass " + i + " target.");
-					return;
-				}
-			}
-			else {
-				console.error("Render queue contains RenderPass of unsupported type!");
+			// Validate preprocess output
+			if (preprocOutput.scene === undefined || !(preprocOutput.scene instanceof Scene) ||
+				preprocOutput.camera === undefined || !(preprocOutput.camera instanceof Camera)) {
+				console.error("Render pass " + i + " has invalid preprocess output!");
 				return;
 			}
 
-			// Postprocessing step
-			renderPass.postprocess(this._textureMap, this._forwardedAdditionalData);
+			// Render to specified target
+			if (renderPass.target === RenderPass.SCREEN) {
+				// RENDER TO SCREEN
+				// Set requested viewport
+				this._renderer.updateViewport(viewportRP.width, viewportRP.height);
+
+				// Render to screen
+				this._renderer.render(preprocOutput.scene, preprocOutput.camera);
+			}
+			else if (renderPass.target === RenderPass.TEXTURE) {
+				// RENDER TO TEXTURE
+				// Setup render target as the render pass specifies
+				this._setupRenderTarget(renderPass);
+
+				// Render to render target
+				this._renderer.render(preprocOutput.scene, preprocOutput.camera, this._renderTarget)
+			}
+			else if (renderPass.target === RenderPass.TEXTURE_CUBE_MAP) {
+				// RENDER TO TEXTURE_CUBE_MAP
+				// Setup render target as the render pass specifies
+				this._setupRenderTarget(renderPass);
+
+				// Render to render target
+				this._renderer.render(preprocOutput.scene, preprocOutput.camera, this._renderTarget, true, renderPass.side);
+			}
+			else {
+				console.error("Unknown render pass " + i + " target.");
+				return;
+			}
+		}
+		else if (renderPass.type === RenderPass.TEXTURE_MERGE) {
+			// This is a texture merging render pass
+
+			// Validate preprocess output
+			if (preprocOutput.material === undefined || !(preprocOutput.material instanceof CustomShaderMaterial) ||
+				preprocOutput.textures === undefined || !Array.isArray(preprocOutput.textures)) {
+				console.error("Render pass " + i + " has invalid preprocess output!");
+				return;
+			}
+
+			// Remove possible previous maps
+			preprocOutput.material.clearMaps();
+
+			// Add textures to material
+			for (let i = 0; i < preprocOutput.textures.length; i++) {
+				preprocOutput.material.addMap(preprocOutput.textures[i]);
+			}
+
+			// Set quad material so that the correct shader will be used
+			this._textureMergeQuad.material = preprocOutput.material;
+
+			// Render to specified target
+			if (renderPass.target === RenderPass.SCREEN) {
+				// RENDER TO SCREEN
+				// Set requested viewport
+				this._renderer.updateViewport(viewportRP.width, viewportRP.height);
+
+				// Render to screen
+				this._renderer.render(this._textureMergeScene, this._textureMergeCamera);
+			}
+			else if (renderPass.target === RenderPass.TEXTURE) {
+				// RENDER TO TEXTURE
+				// Setup render target as the render pass specifies
+				this._setupRenderTarget(renderPass);
+
+				// Render to render target
+				this._renderer.render(this._textureMergeScene, this._textureMergeCamera, this._renderTarget);
+			}
+			else {
+				console.error("Unknown render pass " + i + " target.");
+				return;
+			}
+		}
+		else if (renderPass.type === RenderPass.POSTPROCESS) {
+			// This is a texture merging render pass
+
+			// Validate preprocess output
+			if (preprocOutput.material === undefined || !(preprocOutput.material instanceof CustomShaderMaterial) ||
+				preprocOutput.textures === undefined || !Array.isArray(preprocOutput.textures)) {
+				console.error("Render pass " + i + " has invalid preprocess output!");
+				return;
+			}
+
+			// Remove possible previous maps
+			preprocOutput.material.clearMaps();
+
+			// Add textures to material
+			for (let i = 0; i < preprocOutput.textures.length; i++) {
+				preprocOutput.material.addMap(preprocOutput.textures[i]);
+			}
+
+			// Set quad material so that the correct shader will be used
+			this._textureMergeQuad.material = preprocOutput.material;
+
+			// Render to specified target
+			if (renderPass.target === RenderPass.SCREEN) {
+				// RENDER TO SCREEN
+				// Set requested viewport
+				this._renderer.updateViewport(viewportRP.width, viewportRP.height);
+
+				// Render to screen
+				this._renderer.render(this._textureMergeScene, this._textureMergeCamera);
+			}
+			else if (renderPass.target === RenderPass.TEXTURE) {
+				// RENDER TO TEXTURE
+				// Setup render target as the render pass specifies
+				this._setupRenderTarget(renderPass);
+
+				// Render to render target
+				this._renderer.render(this._textureMergeScene, this._textureMergeCamera, this._renderTarget);
+			}
+			else {
+				console.error("Unknown render pass " + i + " target.");
+				return;
+			}
+		}
+		else {
+			console.error("Render queue contains RenderPass of unsupported type!");
+			return;
 		}
 
+		// Postprocessing step
+		renderPass.postprocess(this._textureMap, this._forwardedAdditionalData);
+	}
+
+	render_end() {
 		// Restore viewport to original value
-		this._renderer.updateViewport(cleanupViewport.width, cleanupViewport.height);
+		this._renderer.updateViewport(this._saved_vp.width, this._saved_vp.height);
+		delete this._saved_vp;
 
 		return {textures: this._textureMap,
 				additionalData: this._forwardedAdditionalData};
+	}
+
+	render() {
+		this.render_begin();
+
+		for (let i = 0; i < this._renderQueue.length; i++) {
+			this.render_pass(this._renderQueue[i]);
+		}
+
+		return this.render_end();
 	}
 
 	addTexture(name, texture) {

--- a/src/renderers/RenderTarget.js
+++ b/src/renderers/RenderTarget.js
@@ -50,7 +50,7 @@ export class RenderTarget {
 		this._depthTexture = texture;
 	}
 
-	addDepthTexture(isCube) {
+	addDepthTexture(isCube=false) {
 		if(isCube){
 			this._depthTexture = new CubeTexture({
 				textures: undefined,

--- a/src/renderers/Renderer.js
+++ b/src/renderers/Renderer.js
@@ -338,6 +338,7 @@ export class Renderer {
 	set clearColor(hexColor) {
 		let components = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hexColor);
 		if (components) {
+			// Is this correct for INT/UINT buffers? See also GLManager.clearSeparate()
 			this._glManager.setClearColor(parseInt(components[1], 16) / 255, parseInt(components[2], 16) / 255, parseInt(components[3], 16) / 255, parseInt(components[4], 16) / 255);
 		}
 	}

--- a/src/shaders/basic/basic_zline_template.frag
+++ b/src/shaders/basic/basic_zline_template.frag
@@ -1,8 +1,10 @@
 #version 300 es
 precision mediump float;
+precision highp sampler2D;
+precision highp isampler2D;
 
 //DEF
-//**********************************************************************************************************************
+//-----------------------------------------------------------------------------
 
 #define SPRITE_SPACE_WORLD 0.0
 #define SPRITE_SPACE_SCREEN 1.0
@@ -10,9 +12,10 @@ precision mediump float;
 struct Material {
     vec3 emissive;
     vec3 diffuse;
-    #if (INSTANCED)
-        sampler2D instanceData0;
-    #fi
+
+    sampler2D  instanceData0;
+    isampler2D instanceData1;
+
     #if (TEXTURE)
         #for I_TEX in 0 to NUM_TEX
             sampler2D texture##I_TEX;
@@ -22,7 +25,7 @@ struct Material {
 
 
 //UIO
-//**********************************************************************************************************************
+//-----------------------------------------------------------------------------
 
 uniform Material material;
 uniform vec3 ambient;
@@ -46,10 +49,9 @@ uniform vec3 ambient;
     layout(location = 0) out vec4 objectID;
 #else if (PICK_MODE_UINT)
     uniform uint u_UINT_ID;
-    #if (INSTANCED)
-        uniform bool u_PickInstance;
-        flat in uint InstanceID;
-    #fi
+
+    uniform bool u_PickInstance;
+    flat in uint InstanceID;
     layout(location = 0) out uint objectID;
 #else if (OUTLINE)
     // in vec3 v_position_viewspace;
@@ -78,7 +80,7 @@ uniform vec3 ambient;
 
 
 //MAIN
-//**********************************************************************************************************************
+//-----------------------------------------------------------------------------
 void main() {
 
     #if (CLIPPING_PLANES)
@@ -120,15 +122,11 @@ void main() {
         #if (PICK_MODE_RGB)
             objectID = vec4(u_RGB_ID, 1.0);
         #else if (PICK_MODE_UINT)
-            #if (INSTANCED)
-                if (u_PickInstance) {
-                    objectID = InstanceID; // 0 is a valid result
-                } else {
-                    objectID = u_UINT_ID;
-                }
-            #else
+            if (u_PickInstance) {
+                objectID = InstanceID; // 0 is a valid result
+            } else {
                 objectID = u_UINT_ID;
-            #fi
+            }
         #else
             outColor = color;
         #fi

--- a/src/shaders/basic/basic_zline_template.vert
+++ b/src/shaders/basic/basic_zline_template.vert
@@ -1,0 +1,154 @@
+#version 300 es
+precision mediump float;
+precision highp sampler2D;
+precision highp isampler2D;
+
+//DEF
+//-----------------------------------------------------------------------------
+
+#define SPRITE_SPACE_WORLD 0.0
+#define SPRITE_SPACE_SCREEN 1.0
+
+// Always INSTANCED
+struct Material {
+    vec3 emissive;
+    vec3 diffuse;
+    sampler2D  instanceData0;
+    isampler2D instanceData1;
+
+    #if (TEXTURE)
+        #for I_TEX in 0 to NUM_TEX
+            sampler2D texture##I_TEX;
+        #end
+    #fi
+};
+
+//UIO
+//-----------------------------------------------------------------------------
+uniform mat4 MVMat; // Model View Matrix
+uniform mat4 PMat;  // Projection Matrix
+uniform vec2 viewport;
+uniform float SpriteMode;
+uniform vec2 SpriteSize;
+
+uniform int  u_OffsetSegs;
+// uniform int  u_OffsetLineInfo;    // line id to segment range
+// uniform int  u_OffsetSegmentInfo; // segment to line id
+
+in vec3 VPos;       // Vertex position
+
+#if (COLORS)
+    in vec4 VColor;
+    out vec4 fragVColor;
+#fi
+
+#if (TEXTURE)
+    in vec2 uv;
+    out vec2 fragUV;
+#fi
+
+#if (CLIPPING_PLANES)
+    out vec3 vViewPosition;
+#fi
+
+// Always INSTANCED
+uniform Material material;
+#if (PICK_MODE_UINT)
+    flat out uint InstanceID;
+#fi
+#if (OUTLINE)
+    uniform bool u_OutlineGivenInstances;
+    in  int  a_OutlineInstances;
+#fi
+
+#if (OUTLINE)
+    out vec3 v_normal_viewspace;
+    out vec3 v_ViewDirection_viewspace;
+#fi
+
+//
+
+int get_sid(int iid) {
+    int   tsx = textureSize(material.instanceData1, 0).x;
+    ivec2 tc  = ivec2(iid % tsx, iid / tsx);
+    return texelFetch(material.instanceData1, tc, 0).r;
+
+    // XXX missing two level lookup!
+}
+
+vec3 get_point(int sid) {
+    int   tsx = textureSize(material.instanceData0, 0).x;
+    ivec2 tc  = ivec2(sid % tsx, sid / tsx);
+    return texelFetch(material.instanceData0, tc, 0).xyz;
+}
+
+//MAIN
+//-----------------------------------------------------------------------------
+void main()
+{
+    int iID = gl_InstanceID;
+    #if (OUTLINE)
+        if (u_OutlineGivenInstances)
+            iID = a_OutlineInstances;
+    #fi
+
+    int sid = get_sid(iID);
+    
+    // sid = 1 + gl_InstanceID * 20;
+
+    vec3 p1 = get_point(get_sid(iID))    ;// + vec3(1.0, 1.0, 0.0);
+    vec3 p2 = get_point(get_sid(iID) + 1);// + vec3(1.0, 1.0, 0.0);
+
+    //p1 = vec3(-14.0, -5.0, 1.0);
+    //p2 = vec3(-10.0, 5.0, -1.0);
+
+    // view-space
+    vec3 p1_vs  = (MVMat * vec4(p1, 1.0)).xyz;
+    vec3 p2_vs  = (MVMat * vec4(p2, 1.0)).xyz;
+    vec3 p12_vs = p2_vs - p1_vs;
+    // Rotate (x,y) of delta 90 deg to the right and normalize.
+    // XXXX ??? degenerate case? line perpendicular to view ???
+    // vec3 tgt = normalize( vec3(-p12_vs.y, p12_vs.x, 0.0) );
+    vec3 tgt = ( vec3(-p12_vs.y, p12_vs.x, 0.0) );
+
+    // Position of the line center in viewspace.
+    vec3 p_vs = p1_vs + VPos.x * p12_vs;
+
+    if(SpriteMode == SPRITE_SPACE_WORLD)
+    {
+        // Assume vertices in x,y plane, z = 0; close to (0, 0) as SpriteSize
+        // will scale them (for centered sprite there should be a quad with x, y = +-0.5).
+
+        gl_Position = PMat * vec4(p1_vs + VPos.x * p12_vs + VPos.y * tgt, 1.0);
+    }
+    else if(SpriteMode == SPRITE_SPACE_SCREEN)
+    {
+        vec4 VPos_clipspace = PMat * vec4(p_vs, 1.0);
+        gl_Position = VPos_clipspace + vec4(VPos.xy * 2.0 * SpriteSize.xy / viewport * VPos_clipspace.w, 0.0, 0.0);
+    }
+
+    #if (COLORS)
+        // Pass vertex color to fragment shader
+        fragVColor = VColor;
+    #fi
+
+    #if (TEXTURE)
+        // Pass uv coordinate to fragment shader
+        fragUV = uv;
+    #fi
+
+    #if (CLIPPING_PLANES)
+        vViewPosition = -p_vs;
+    #fi
+
+    #if (OUTLINE)
+        v_normal_viewspace = vec3(0.0, 0.0, -1.0);
+
+        float dToCam = length(p_vs);
+        v_ViewDirection_viewspace = -p_vs / dToCam;
+    #fi
+
+    #if (PICK_MODE_UINT)
+        InstanceID = uint(iID);
+    #fi
+ }

--- a/src/shaders/basic/basic_zsprite_template.vert
+++ b/src/shaders/basic/basic_zsprite_template.vert
@@ -44,14 +44,6 @@ in vec3 VPos;       // Vertex position
     out vec2 fragUV;
 #fi
 
-#if (PLIGHTS)
-    out vec3 fragVPos;
-#fi
-
-#if (POINTS)
-    uniform float pointSize;
-#fi
-
 #if (CLIPPING_PLANES)
     out vec3 vViewPosition;
 #fi
@@ -106,11 +98,6 @@ void main() {
         vec4 VPos_clipspace = PMat * VPos_viewspace;
         gl_Position = VPos_clipspace + vec4(VPos.xy * 2.0 * SpriteSize.xy / viewport * VPos_clipspace.w, 0.0, 0.0);
     }
-
-    #if (PLIGHTS)
-        // Pass vertex position to fragment shader
-        fragVPos = vec3(VPos_viewspace) / VPos_viewspace.w;
-    #fi
 
     #if (COLORS)
         // Pass vertex color to fragment shader

--- a/src/shaders/basic/basic_zsprite_template.vert
+++ b/src/shaders/basic/basic_zsprite_template.vert
@@ -11,7 +11,7 @@ precision mediump float;
 struct Material {
     vec3 emissive;
     vec3 diffuse;
-    sampler2D instanceData;
+    sampler2D instanceData0;
     // The following could (should, really) be an int attribute with divisor 1
     // #if (OUTLINE)
     //    isampler2D instance_indices;
@@ -76,9 +76,9 @@ void main() {
             if (u_OutlineGivenInstances)
                 iID = a_OutlineInstances;
         #fi
-        int   tsx = textureSize(material.instanceData, 0).x;
+        int   tsx = textureSize(material.instanceData0, 0).x;
         ivec2 tc  = ivec2(iID % tsx, iID / tsx);
-        vec4  pos = texelFetch(material.instanceData, tc, 0);
+        vec4  pos = texelFetch(material.instanceData0, tc, 0);
         // see also texelFetchOffset about how to get neigboring texels
 
         VPos_viewspace = MVMat * vec4(pos.xyz, 1.0);

--- a/src/shaders/custom/GBuffer/GBufferMini_template.frag
+++ b/src/shaders/custom/GBuffer/GBufferMini_template.frag
@@ -6,9 +6,6 @@ precision mediump float;
 //**********************************************************************************************************************//
 #if (NORMAL_FLAT)
 in vec3 v_position_viewspace;
-vec3 fdx = dFdx(v_position_viewspace);
-vec3 fdy = dFdy(v_position_viewspace);
-vec3 v_normal_viewspace = normalize(cross(fdx, fdy));
 #else if (!NORMAL_FLAT)
 in vec3 v_normal_viewspace;
 #fi
@@ -55,6 +52,12 @@ void main() {
     #fi
 
     //******************************************************************************************************************//
+
+    #if (NORMAL_FLAT)
+        vec3 fdx = dFdx(v_position_viewspace);
+        vec3 fdy = dFdy(v_position_viewspace);
+        vec3 v_normal_viewspace = normalize(cross(fdx, fdy));
+    #fi
 
     vn_viewspace = vec4(v_normal_viewspace, 0.0);
     vd_viewspace = vec4(v_ViewDirection_viewspace, 0.0);

--- a/src/shaders/custom/post_process/ToneMapping.frag
+++ b/src/shaders/custom/post_process/ToneMapping.frag
@@ -49,7 +49,9 @@ void main() {
         // gamma correction 
         mapped = pow(mapped, vec3(1.0 / gamma));
     
-        //ldrColor = vec4(mapped, 1.0);
-        ldrColor = mix(vec4(u_clearColor.rgb, 1.0), vec4(mapped, 1.0), hdrColor.a);
+        if (hdrColor.a == 0.0)
+            ldrColor = vec4(u_clearColor.rgb, 1.0);
+        else
+            ldrColor = vec4(mapped, 1.0);
     #fi
 }

--- a/src/shaders/programs.json
+++ b/src/shaders/programs.json
@@ -74,6 +74,13 @@
             "fragment": "basic/basic_zsprite_template.frag"
         }
     },
+    "basic_zline": {
+        "description": "ZLine instanced through texture; supports PICKING and OUTLINE modes.",
+        "shaders": {
+            "vertex": "basic/basic_zline_template.vert",
+            "fragment": "basic/basic_zline_template.frag"
+        }
+    },
 
     "basic_stripe": {
         "description": "Default gl2 program used for testing.",


### PR DESCRIPTION
1. Prep work for by-hand RenderQueue iteration and ZLine object.

- Remove d/p/s-lights from zsprite shaders.

- GLTextureManager: revert UNPACK_FLIP_Y_WEBGLstate after texImage2D().

- GLTextureManager: support INT texture type.

- RenderQueue: break render() into render_begin() / render_pass() /
  render_end() so it is easier to steer for specific use cases where certain
  passes might be skipped, repeated, or require additional input / output
  setup depending on outside circumstances.

- Material: allow multiple instanceData textures

- Preliminary ZLine testing still using ZSprite and ZSpriteMaterial as
  drivers, only proto shaders are implemented. Point data is read from
  float-rgba texture and segment to point-index lookup is read from int-red
  texture, both set as instanceData.

2. REve integration of new outline implementation

- ToneMapping.frag - do not map background (alpha = 0).

- GBufferMini_template.frag - fix NORMAL_FLAT.

- RenderQueue - missing variable in console.log printouts.

- Renderer - add comment about default clearColor for int / uint color attachments.

- RenderPass - consistent definitions of clearFunction.

- GLManager / RenderQueue - allow specification of clearColorArray on texture template.
  If clearColorArray is null, buffer will not be cleared without warning.
  clearColorArray, when set, should be appropriate 4-element native array for the buffer format.
  When clear color is not set, the buffer will be cleared with renderer's clear color.

- MeshRenderer - add defualt outline material for objects using normalFlat.

- GLManager - set depthMask to true before clearing depth buffer.
