### PR TITLE
Support picking with reduced viewport in REve.

### DIFF
--- a/src/cameras/Camera.js
+++ b/src/cameras/Camera.js
@@ -150,4 +150,28 @@ export class Camera extends Object3D {
         const fru12 = new Line(fru12g);
         this._frustum.add(fru12);
 	}
+
+    // Functions to render with a smaller viewport around the mouse pointer.
+    // Works for both Persp and Ortho cameras.
+	prePickStoreTBLR() {
+		this._top_store = this._top;
+		this._bottom_store = this._bottom;
+		this._left_store = this._left;
+		this._right_store = this._right;
+	}
+	narrowProjectionForPicking(w, h, p, q, x, y) {
+		// w, h - viewport; p, q - pick rectangle; x,y - pick position in viewport coords.
+		this._top = (y + q/2)/h*(this._top_store - this._bottom_store) + this._bottom_store;
+		this._bottom = (y - q/2)/h*(this._top_store - this._bottom_store) + this._bottom_store;
+		this._left = (x - p/2)/w*(this._right_store - this._left_store) + this._left_store;
+		this._right = (x + p/2)/w*(this._right_store - this._left_store) + this._left_store;
+		this.updateProjectionMatrix();
+	}
+	postPickRestoreTBLR() {
+		this._top = this._top_store;
+		this._bottom = this._bottom_store;
+		this._left = this._left_store;
+		this._right = this._right_store;
+		this.updateProjectionMatrix();
+	}
 }

--- a/src/renderers/MeshRenderer.js
+++ b/src/renderers/MeshRenderer.js
@@ -191,11 +191,11 @@ export class MeshRenderer extends Renderer {
 		this._renderPickableObjects(opaqueObjects, camera);
 		this._renderPickableObjects(transparentObjects, camera);
 
-		let r = new Uint32Array(1);
-		this._gl.readPixels(this._pickCoordinateX, this._canvas.height - this._pickCoordinateY, 1, 1, this._gl.RED_INTEGER, this._gl.UNSIGNED_INT, r);
+		let r = new Uint32Array(4);
+		this._gl.readBuffer(this._gl.COLOR_ATTACHMENT0);
+		this._gl.readPixels(this._pickCoordinateX, this._pickCoordinateY, 1, 1,
+			                this._gl.RGBA_INTEGER, this._gl.UNSIGNED_INT, r);
 		this._pickedID = (r[0] != 0xFFFFFFFF) ? r[0] : null;
-
-		console.log("MeshRenderer pickID:", this._pickedID);
 
 		if (this._pickObject3D) {
 			this._pickedObject3D = (this._pickedID !== null) ? this._pickLUA[this._pickedID] : null;
@@ -1254,8 +1254,10 @@ export class MeshRenderer extends Renderer {
 		this._drawObject(object);
 		object.pickingMaterial.setUniform("u_PickInstance", false);
 
-		let r = new Uint32Array(1);
-		this._gl.readPixels(this._pickCoordinateX, this._canvas.height - this._pickCoordinateY, 1, 1, this._gl.RED_INTEGER, this._gl.UNSIGNED_INT, r);
+		let r = new Uint32Array(4);
+		this._gl.readBuffer(this._gl.COLOR_ATTACHMENT0);
+		this._gl.readPixels(this._pickCoordinateX, this._pickCoordinateY, 1, 1,
+			                this._gl.RGBA_INTEGER, this._gl.UNSIGNED_INT, r);
 		this._pickedID = (r[0] != 0xFFFFFFFF) ? r[0] : null;
 
 		console.log("MeshRenderer pick_instance InstanceID:", this._pickedID);

--- a/src/renderers/Renderer.js
+++ b/src/renderers/Renderer.js
@@ -290,7 +290,7 @@ export class Renderer {
 		let rttViewport = renderTarget._viewport;
 
 		// Setup viewport
-		this._gl.viewport(rttViewport.x, rttViewport.y, rttViewport.z, rttViewport.w);
+		this.updateViewport(rttViewport.z, rttViewport.w, rttViewport.x, rttViewport.y);
 
 		if(cubeTarget){
 			this._glManager.initRenderTargetCube(renderTarget, side);
@@ -301,7 +301,8 @@ export class Renderer {
 
 	_cleanupRenderTarget() {
 		this._currentRenderTarget = null;
-		this._gl.viewport(0, 0, this._canvas.width, this._canvas.height);
+
+		this.updateViewport(this._canvas.width, this._canvas.height);
 
 		this._glManager.cleanupRenderTarget();
 	}
@@ -415,7 +416,7 @@ export class Renderer {
 		const width = (reference)? reference.width : this.getViewport().width;
 		const height = (reference)? reference.height : this.getViewport().height;
 
-		const pickedUINT = new Uint32Array(1);
+		const pickedUINT = new Uint32Array(4);
 
 		//PREP
 		if(reference){
@@ -426,7 +427,7 @@ export class Renderer {
 		}
 
 		//READ
-		this._gl.readPixels(pickX, height-pickY, 1, 1, this._gl.RED_INTEGER, this._gl.UNSIGNED_INT, pickedUINT);
+		this._gl.readPixels(pickX, height-pickY, 1, 1, this._gl.RGBA_INTEGER, this._gl.UNSIGNED_INT, pickedUINT);
 
 		//CLEAN
 		if(reference){


### PR DESCRIPTION
- Camera - add functions to setup top/bottom/left/right frustum clipping planes for picking in a reduced viewport.

- Renderer - updateViewport also when rendering into textures - the vieport uniform needs to be set correctly from MeshRenderer.

- MeshRenderer - for UINT picking read out values into RGBA_INTEGER (red-only output formats not supported on Firefox).

- examples/outlineExample/main-ZSprite.js - update for new outline/blur/blend.