### PR TITLE
Changes needed to implement multiple outline passes in REve.

### DIFF
--- a/src/cameras/Camera.js
+++ b/src/cameras/Camera.js
@@ -152,20 +152,12 @@ export class Camera extends Object3D {
 	}
 
     // Functions to render with a smaller viewport around the mouse pointer.
-    // Works for both Persp and Ortho cameras.
+    // See also narrowProjectionForPicking() in Persp and Ortho cameras.
 	prePickStoreTBLR() {
 		this._top_store = this._top;
 		this._bottom_store = this._bottom;
 		this._left_store = this._left;
 		this._right_store = this._right;
-	}
-	narrowProjectionForPicking(w, h, p, q, x, y) {
-		// w, h - viewport; p, q - pick rectangle; x,y - pick position in viewport coords.
-		this._top = (y + q/2)/h*(this._top_store - this._bottom_store) + this._bottom_store;
-		this._bottom = (y - q/2)/h*(this._top_store - this._bottom_store) + this._bottom_store;
-		this._left = (x - p/2)/w*(this._right_store - this._left_store) + this._left_store;
-		this._right = (x + p/2)/w*(this._right_store - this._left_store) + this._left_store;
-		this.updateProjectionMatrix();
 	}
 	postPickRestoreTBLR() {
 		this._top = this._top_store;
@@ -174,4 +166,4 @@ export class Camera extends Object3D {
 		this._right = this._right_store;
 		this.updateProjectionMatrix();
 	}
-}
+};

--- a/src/cameras/OrthographicCamera.js
+++ b/src/cameras/OrthographicCamera.js
@@ -203,4 +203,24 @@ export class OrthographicCamera extends Camera {
 			this.updateProjectionMatrix();
 		}
 	}
+
+	narrowProjectionForPicking(w, h, p, q, x, y) {
+		// w, h - viewport; p, q - pick rectangle; x,y - pick position in viewport coords.
+		let dx = (this._right_store - this._left_store) / (2 * this._zoom);
+		let dy = (this._top_store - this._bottom_store) / (2 * this._zoom);
+		let cx = (this._right_store + this._left_store) / 2;
+		let cy = (this._top_store + this._bottom_store) / 2;
+
+		let left = cx - dx;
+		let right = cx + dx;
+		let top = cy + dy;
+		let bottom = cy - dy;
+
+		let qtop = (y + q/2)/h*(top - bottom) + bottom;
+		let qbottom = (y - q/2)/h*(top - bottom) + bottom;
+		let qleft = (x - p/2)/w*(right - left) + left;
+		let qright = (x + p/2)/w*(right - left) + left;
+		this.projectionMatrix.makeOrthographic(qleft, qright, qtop, qbottom, this._near, this._far);
+		if (this.frustumVisible) this.updateFrustum();
+	}
 };

--- a/src/cameras/PerspectiveCamera.js
+++ b/src/cameras/PerspectiveCamera.js
@@ -292,4 +292,13 @@ export class PerspectiveCamera extends Camera {
 			this.updateProjectionMatrix();
 		}
 	}
+
+	narrowProjectionForPicking(w, h, p, q, x, y) {
+		// w, h - viewport; p, q - pick rectangle; x,y - pick position in viewport coords.
+		this._top = (y + q/2)/h*(this._top_store - this._bottom_store) + this._bottom_store;
+		this._bottom = (y - q/2)/h*(this._top_store - this._bottom_store) + this._bottom_store;
+		this._left = (x - p/2)/w*(this._right_store - this._left_store) + this._left_store;
+		this._right = (x + p/2)/w*(this._right_store - this._left_store) + this._left_store;
+		this.updateProjectionMatrix();
+	}
 };

--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -56,8 +56,11 @@ export class BufferAttribute {
 	 * @param val Value to be set.
 	 */
 	set array(val) {
+		if (this._array.length == val.length)
+			this._update = true;
+		else
+			this._dirty = true;
 		this._array = val;
-		this._dirty = true;
 	}
 
 	/**

--- a/src/core/GLAttributeManager.js
+++ b/src/core/GLAttributeManager.js
@@ -72,10 +72,14 @@ export class GLAttributeManager {
 		// If the WebGL buffer property is undefined, create a new buffer (attribute not found in properties)
 		if (attribute.dirty || attribute._update) {
 			this._gl.bindBuffer(bufferType, glBuffer);
+			if (attribute.dirty) {
+				const usage = this.DRAW_TYPE.get(attribute.drawType);
+				this._gl.bufferData(bufferType, attribute.size, usage); // recreate buffer
+				attribute.dirty = false; // Mark attribute not dirty
+			}
 			//this._gl.bufferSubData(bufferType, 0, attribute.array); // Write the data to buffer
 			this._gl.bufferSubData(bufferType, 0, attribute.array, 0, 0);
 
-			attribute.dirty = false; // Mark attribute not dirty
 			attribute._update = false;
 		}
 	}
@@ -90,14 +94,14 @@ export class GLAttributeManager {
 
 		if(this._cached_buffers.has(attribute)){
 			const glBuffer = this._cached_buffers.get(attribute);
-			if(attribute.dirty) this._updateAttribute(attribute);
+			if(attribute.dirty || attribute._update) this._updateAttribute(attribute);
 
 
 			return glBuffer; 
 		}else{
 			//console.error("Warning: GLBuffer not found: [" + attribute + "]!");
 			const glBuffer = this._createGLBuffer(attribute);
-			if(attribute.dirty) this._updateAttribute(attribute);
+			if(attribute.dirty || attribute._update) this._updateAttribute(attribute);
 			
 
 			return glBuffer;

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -113,6 +113,10 @@ export class Object3D {
 		this._matrix = matrix;
 		this._matrixWorldNeedsUpdate = true;
 	}
+	setMatrixFromArray(arr) {
+		this._matrix.fromArray(arr);
+		this._matrixWorldNeedsUpdate = true;
+	}
 	/**
 	 * Get model view matrix of the mesh.
 	 *

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -380,23 +380,23 @@ export class Object3D {
 		this._UPDATE_BOUNDS = true;
 	}
 
-	updateMatrixWorld() {
+	updateMatrixWorld(parentWorldUpdated = false) {
 		if ( this._matrixAutoUpdate ) this.updateMatrix();
 
-		if (this._matrixWorldNeedsUpdate) {
+		if (this._matrixWorldNeedsUpdate || parentWorldUpdated) {
 			if (this.parent === null) {
 				this._matrixWorld.copy(this._matrix);
 			} else {
 				this._matrixWorld.multiplyMatrices(this.parent._matrixWorld, this._matrix);
 			}
 			this._matrixWorldNeedsUpdate = false;
-
+			parentWorldUpdated = true;
 
 			this._UPDATE_BOUNDS = true;
 		}
 
 		for (var i = 0; i < this._children.length; i++) {
-			this._children[i].updateMatrixWorld();
+			this._children[i].updateMatrixWorld(parentWorldUpdated);
 		}
 	}
 	//THREE version of matrix world update

--- a/src/program_management/ShaderBuilder.js
+++ b/src/program_management/ShaderBuilder.js
@@ -55,7 +55,8 @@ export class ShaderBuilder {
 
 		// Warn the user if the template tree is beeing overwritten
 		if (this.hasTemplate(templateName)) {
-			console.log(this._LOGTAG + "Warning. Overwriting the template tree!");
+			console.log(this._LOGTAG + "Warning. Overwriting the template tree!", templateName);
+			return;
 		}
 
 		// Remove multi line comments

--- a/src/renderers/MeshRenderer.js
+++ b/src/renderers/MeshRenderer.js
@@ -130,6 +130,7 @@ export class MeshRenderer extends Renderer {
 				console.log(this._compiledPrograms);
 				console.log("--------------------------------------");
 			}
+			this.used = false;
 			return;
 		}
 		if(!this.used) {
@@ -1259,8 +1260,6 @@ export class MeshRenderer extends Renderer {
 		this._gl.readPixels(this._pickCoordinateX, this._pickCoordinateY, 1, 1,
 			                this._gl.RGBA_INTEGER, this._gl.UNSIGNED_INT, r);
 		this._pickedID = (r[0] != 0xFFFFFFFF) ? r[0] : null;
-
-		console.log("MeshRenderer pick_instance InstanceID:", this._pickedID);
 
 		return this._pickedID;
 	}

--- a/src/renderers/Renderer.js
+++ b/src/renderers/Renderer.js
@@ -209,20 +209,20 @@ export class Renderer {
 			if (scope._logLevel >= 2)
 				console.log("(Down)loaded: " + program.programID + ": " + programName + '.');
 			scope._glProgramManager.addTemplate(programTemplateSrc);
-			scope._loadingPrograms.delete(program.programID);
+			scope._loadingPrograms.delete(program.name);
 		};
 
 		// Something went wrong while fetching the program templates
 		let onError = function (event) {
 			console.error("Failed to load program: " + program.programID + ": " + programName + '.');
-			scope._loadingPrograms.delete(program.programID);
+			scope._loadingPrograms.delete(program.name);
 		};
 
 		// Check if the program is already loading
-		if (!this._loadingPrograms.has(program.programID)) {
+		if (!this._loadingPrograms.has(program.name)) {
 			if (this._logLevel >= 2)
 				console.log("(Down)loading: " + program.programID + ": " + programName + '.');
-			this._loadingPrograms.set(program.programID, program);
+			this._loadingPrograms.set(program.name, program);
 
 			// Initiate loading
 			this._shaderLoader.loadProgramSources(programName, onLoad, undefined, onError);

--- a/src/shaders/custom/post_process/outline.frag
+++ b/src/shaders/custom/post_process/outline.frag
@@ -104,6 +104,12 @@ void main() {
 
         // Edge decision
         float edge = max(edgeDepth, edgeNormal); //edge is either 0 or 1
+
+        #if (DISCARD_NON_EDGE)
+            if (edge == 0.0)
+                discard;
+        #fi
+
         // Edge color
         vec4 edgeColor = vec4(edgeColor.rgb, edgeColor.a * edge);
 


### PR DESCRIPTION
- BufferAttribute, GLAttributeManager - use BufferAttribute.dirty flag to signal size of array has changed and requires regeneration in GL. Update means only data has changed and needs to be copied into existing GL buffer. Before meaning between the two was ambiguous.

- Object3D.updateMatrixWorld() - add argument parentWorldUpdated = false and properly propagate it down to children. If parent world-matrix changes, all children need to update it, too!

- MeshRenderer - reset used flag if not all programs are available.

- RenderQueue - add state for optionally detecting how many render-passes did not execute due to missing programs.

- Renderer - use program.name as key into Map programs that are currently being loaded by ShaderLoader. programID was used before and this is different for different values of SBflags -- and we are only interested in program text at this point.

- shaders/custom/post_process/outline.frag - odd SBflag DISCARD_NON_EDGE that allows additive writing into existing texture when several different outlines need to be accumulated (and then blurred together).