### PR TITLE
Fix webgl lint and rollup.js complaints, allow extraction of used shader catalog.

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -67,9 +67,6 @@ export const TRIANGLES = 4;
 export const TRIANGLE_STRIP = 5;
 export const TRIANGLE_FAN = 6;
 
-// GL Manager constants
-// ./core/GLManager
-export const _ProgramCaching = null;
 
 // GL Program Manager constants
 // ./program_management/GLProgramManager

--- a/src/core/GLManager.js
+++ b/src/core/GLManager.js
@@ -1,7 +1,7 @@
 /**
  * Created by Primoz on 24.4.2016.
  */
-import {WEBGL1, WEBGL2, _ProgramCaching} from '../constants.js';
+import {WEBGL1, WEBGL2} from '../constants.js';
 import {GLFrameBufferManager} from './GLFrameBufferManager.js';
 import {GLTextureManager} from './GLTextureManager.js';
 import {GLAttributeManager} from './GLAttributeManager.js';
@@ -16,6 +16,7 @@ import {Vector4} from '../math/Vector4.js';
 export class GLManager {
 
 	static sCheckFrameBuffer = true;
+	static sProgramCaching = null;
 
 	/**
 	 * Creates new WebGL context manager. The context is retrieved from the given canvas.
@@ -538,9 +539,9 @@ export class GLManager {
 
 	get glVersion () { return this._glVersion; }
 
-	get cache_programs () { return _ProgramCaching; }
+	get cache_programs () { return GLManager.sProgramCaching; }
 
-	set cache_programs (enable) { _ProgramCaching = enable; }
+	set cache_programs (enable) { GLManager.sProgramCaching = enable; }
 
 	get gl(){ return this._gl; }
 

--- a/src/loaders/ShaderLoader.js
+++ b/src/loaders/ShaderLoader.js
@@ -7,6 +7,8 @@ import {XHRLoader} from './XHRLoader.js';
 
 export class ShaderLoader {
 
+	static sAllPrograms = new Set();
+
 	/**
 	 * Creates new ShaderLoader object with the given LoadingManager. If the LoadingManager is not defined..
 	 * Default manager is used.
@@ -195,6 +197,7 @@ export class ShaderLoader {
 
 				var onLoadShader = function (source) {
 					numLoaded ++;
+					ShaderLoader.sAllPrograms.add(program);
 
 					// Check if the onProgress callback was given
 					if (onProgress !== undefined) {
@@ -319,8 +322,21 @@ export class ShaderLoader {
 	/**
 	 * Returns names of available programs
 	 */
-	get programList() { Object.keys(this._programs); }
+	get programList() { return Object.keys(this._programs); }
 
+	/**
+	 * Resolve an iterable list of program names and return a list of copies
+	 * of program entries. This can be used for extraction of a subset of shaders
+	 * for packaging, most likely called with ShaderLoader.sAllPrograms as argument.
+	 * One might want to delete urls property of each element.
+	*/
+	resolvePrograms (name_list) {
+		let prog_list = [];
+		for (let name of name_list) {
+			prog_list.push(structuredClone(this._programs[name]));
+		}
+		return prog_list;
+	}
 
 	// In-order executor
 	executor (executable, ...args) {

--- a/src/materials/StripesBasicMaterial.js
+++ b/src/materials/StripesBasicMaterial.js
@@ -16,7 +16,7 @@ export class StripesBasicMaterial extends StripeBasicMaterial {
 
         //ASSEMBLE MATERIAL
         this.color = args.color ? args.color : new Color(Math.random() * 0xffffff);
-        this._emissive = args.emissive ? args.emissive : new Color(Math.random() * 0xffffff);
+        this.emissive = args.emissive ? args.emissive : new Color(Math.random() * 0xffffff);
 
         //this.setUniform("aspect", args.aspect ? args.aspect : window.innerWidth/window.innerHeight);
         //this.setUniform("viewport", args.viewport ? args.viewport : [window.innerWidth, window.innerHeight]);

--- a/src/materials/StripesBasicMaterial.js
+++ b/src/materials/StripesBasicMaterial.js
@@ -16,6 +16,7 @@ export class StripesBasicMaterial extends StripeBasicMaterial {
 
         //ASSEMBLE MATERIAL
         this.color = args.color ? args.color : new Color(Math.random() * 0xffffff);
+        this._emissive = args.emissive ? args.emissive : new Color(Math.random() * 0xffffff);
 
         //this.setUniform("aspect", args.aspect ? args.aspect : window.innerWidth/window.innerHeight);
         //this.setUniform("viewport", args.viewport ? args.viewport : [window.innerWidth, window.innerHeight]);

--- a/src/program_management/GLProgramManager.js
+++ b/src/program_management/GLProgramManager.js
@@ -241,6 +241,7 @@ export class GLProgramManager {
 			// Fetch uniform info and location
 			const info = self._gl.getActiveUniform(program, i);
 			const location = self._gl.getUniformLocation(program, info.name);
+			if (!location) continue; // Uniform optimized away? Do not try to set it later on.
 
 			uniformSetter[info.name] = {};
 

--- a/src/shaders/basic/basic_stripes_template.frag
+++ b/src/shaders/basic/basic_stripes_template.frag
@@ -7,7 +7,7 @@ precision mediump float;
 #if (DLIGHTS)
 struct DLight {
     //bool directional;
-    vec3 position;
+    //vec3 position;
     vec3 color;
 };
 #fi
@@ -17,7 +17,7 @@ struct PLight {
     vec3 position;
     vec3 color;
     float distance;
-    float decay;
+    //float decay;
 
     float constant;
     float linear;

--- a/src/shaders/basic/basic_stripes_template.frag
+++ b/src/shaders/basic/basic_stripes_template.frag
@@ -27,6 +27,7 @@ struct PLight {
 
 struct Material {
     vec3 diffuse;
+    vec3 emissive;
     #if (TEXTURE)
         #for I_TEX in 0 to NUM_TEX
             sampler2D texture##I_TEX;
@@ -124,7 +125,7 @@ void main() {
 
 
     // Calculate combined light contribution
-    vec3 combined = ambient;
+    vec3 combined = ambient + material.emissive;
 
     #if (LIGHTS && DLIGHTS)
         #for lightIdx in 0 to NUM_DLIGHTS

--- a/src/shaders/basic/basic_template.frag
+++ b/src/shaders/basic/basic_template.frag
@@ -7,7 +7,7 @@ precision mediump float;
 #if (DLIGHTS)
 struct DLight {
     //bool directional;
-    vec3 position;
+    //vec3 position;
     vec3 color;
 };
 #fi
@@ -17,7 +17,7 @@ struct PLight {
     vec3 position;
     vec3 color;
     float distance;
-    float decay;
+    //float decay;
 
     float constant;
     float linear;
@@ -30,7 +30,7 @@ struct SLight {
     vec3 position;
     vec3 color;
     float distance;
-    float decay;
+    //float decay;
     float cutoff;
     float outerCutoff;
     vec3 direction;

--- a/src/shaders/basic/basic_zsprite_template.frag
+++ b/src/shaders/basic/basic_zsprite_template.frag
@@ -9,7 +9,7 @@ precision mediump float;
 
 struct Material {
     vec3 emissive;
-    vec3 diffuse;
+    // vec3 diffuse;
     #if (INSTANCED)
         sampler2D instanceData0;
     #fi

--- a/src/shaders/basic/basic_zsprite_template.vert
+++ b/src/shaders/basic/basic_zsprite_template.vert
@@ -10,7 +10,7 @@ precision mediump float;
 #if (INSTANCED)
 struct Material {
     vec3 emissive;
-    vec3 diffuse;
+    // vec3 diffuse;
     sampler2D instanceData0;
     // The following could (should, really) be an int attribute with divisor 1
     // #if (OUTLINE)

--- a/src/shaders/phong/phong_template-FLAT.vert
+++ b/src/shaders/phong/phong_template-FLAT.vert
@@ -17,7 +17,7 @@ struct PLight {
     vec3 position;
     vec3 color;
     float distance;
-    float decay;
+    //float decay;
 
     float constant;
     float linear;
@@ -30,7 +30,7 @@ struct SLight {
     vec3 position;
     vec3 color;
     float distance;
-    float decay;
+    //float decay;
     float cutoff;
     float outerCutoff;
     vec3 direction;

--- a/src/shaders/phong/phong_template.frag
+++ b/src/shaders/phong/phong_template.frag
@@ -26,7 +26,7 @@ struct PLight {
     vec3 position_worldspace;
     vec3 color;
     float distance;
-    float decay;
+    //float decay;
 
     mat4 VPMat;
     samplerCube shadowmap;
@@ -47,7 +47,7 @@ struct SLight {
     vec3 position;
     vec3 color;
     float distance;
-    float decay;
+    //float decay;
     float cutoff;
     float outerCutoff;
     vec3 direction;

--- a/src/shaders/phong/phong_template.vert
+++ b/src/shaders/phong/phong_template.vert
@@ -26,7 +26,7 @@ struct PLight {
     vec3 position_worldspace;
     vec3 color;
     float distance;
-    float decay;
+    //float decay;
 
     mat4 VPMat;
     samplerCube shadowmap;
@@ -47,7 +47,7 @@ struct SLight {
     vec3 position;
     vec3 color;
     float distance;
-    float decay;
+    // float decay;
     float cutoff;
     float outerCutoff;
     vec3 direction;


### PR DESCRIPTION
* Comment out shader variables as reported by webgl-lint.
* Add ambient color to Stripes frag shader / material.
* Fix GLManager constant issue reported by rollup.
* Add ability to extract a catalog of used shaders from ShaderLoader.