### PR TITLE
Correction in deleteTexture/deleteBuffer: set dirty attribute before …

### DIFF
--- a/src/core/GLAttributeManager.js
+++ b/src/core/GLAttributeManager.js
@@ -113,10 +113,9 @@ export class GLAttributeManager {
 	 * @param {BufferAttribute} attribute An attribute whose local version will be deleted
 	 */
 	deleteBuffer(buffer, glBuffer) {
+		buffer.dirty = true; //so it will be updated when created again
 		this._cached_buffers.delete(buffer);
 		this._gl.deleteBuffer(glBuffer);
-
-		buffer.dirty = true; //so it will be updated when created again
 	}
 
 	/**

--- a/src/core/GLTextureManager.js
+++ b/src/core/GLTextureManager.js
@@ -278,10 +278,9 @@ export class GLTextureManager {
 	}
 
 	deleteTexture(texture, glTexture) {
+		texture._dirty = true;
 		this._cached_textures.delete(texture);
 		this._gl.deleteTexture(glTexture);
-
-		texture.dirty = true;
 	}
 	deleteTextures(checkIdleTime = false, idleTimeDelta = 1000) {
 		// Delete all cached textures


### PR DESCRIPTION
This changes were needed to resolve errors in purge of textures and attributes.