### PR TITLE
Changes for packaging and final integration into ROOT

### DIFF
--- a/dist/reve/Makefile
+++ b/dist/reve/Makefile
@@ -1,0 +1,36 @@
+NPM_DIR := /opt/npm/bin
+CONTRIB_DIR := ../../src/contrib
+
+default:
+	@echo No default target, please specify dist or clean.
+
+dist: REveRenderCore-min.mjs shaders
+	tar cf RenderCore.tar REveRenderCore-min.mjs shaders/
+	gzip -9 RenderCore.tar
+	sha256sum -b RenderCore.tar.gz
+	@echo Now move the tarball to ROOT source and put the checksum into ROOT source tree
+	@echo "  " mv RenderCore.tar.gz ROOT-SRC/builtins/rendercore/
+	@echo and put the SHA256 checksum into:
+	@echo "  " ROOT-SRC/cmake/modules/SearchInstalledSoftware.cmake
+
+clean:
+	rm -rf REveRenderCore.mjs REveRenderCore-min.mjs programs.json shaders RenderCore.tar.gz
+
+# ------------------------------------------------------
+
+REveRenderCore.mjs: ${CONTRIB_DIR}/REveRenderCore.js
+	${NPM_DIR}/rollup $< --format es --file REveRenderCore.mjs
+
+REveRenderCore-min.mjs: REveRenderCore.mjs
+	${NPM_DIR}/uglifyjs REveRenderCore.mjs -c -b indent_level=1 -m -o REveRenderCore-min.mjs
+
+define prog_name_help
+$@ must be created manually. One can use merge-names.js, e.g.:
+    ./merge-names.js ~/Downloads/programs-ev_demo.json ~/Downloads/programs-col_prox.json
+It is safe to include $@ in the list of arguments
+endef
+program_names.json:
+	$(error ${prog_name_help})
+
+shaders: program_names.json
+	./pack-shaders.js

--- a/dist/reve/merge-names.js
+++ b/dist/reve/merge-names.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const os = require("os");
+
+const output = "program_names.json";
+
+const args = process.argv.slice(2);
+
+let prog_names = new Set();
+for (let a of args) {
+    a.replace("~", os.homedir);
+    let name_list = JSON.parse(fs.readFileSync(a));
+    for (let name of name_list) {
+        prog_names.add(name);
+    }
+}
+// console.log(prog_names);
+
+let names = [];
+for (const p of prog_names) names.push(p);
+fs.writeFileSync(output, JSON.stringify(names, null, 2));

--- a/dist/reve/pack-shaders.js
+++ b/dist/reve/pack-shaders.js
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const os = require("os");
+
+const input = "program_names.json";
+const output = "shaders/programs.json";
+
+const src_dir = "../../src/";
+const shaders_dir = src_dir + "shaders/";
+
+const dir_name_re = new RegExp("^(.*/)([^/]+)$");
+
+let name_list = JSON.parse(fs.readFileSync(input));
+
+let shaders = JSON.parse(fs.readFileSync(shaders_dir + "programs.json"));
+// console.log(shaders);
+
+function stat(name) {
+    try {
+        return fs.statSync(name);
+    } catch (err) {
+        return null;
+    }
+}
+
+let result = {};
+for (let name of name_list) {
+    if (shaders[name]) {
+        let shdr = shaders[name];
+        result[name] = shdr;
+
+        // console.log("Adding shader", shdr);
+
+        for (let type in shdr.shaders) {
+            let ss = shdr.shaders[type];
+            let res = ss.match(dir_name_re);
+            // console.log(res);
+
+            // Copy the required file into local sub-dir.
+            let out_dir = 'shaders/' + res[1];
+
+            const dstat = stat(out_dir);
+            if (!dstat) {
+                console.log("Making dir", out_dir);
+                fs.mkdirSync(out_dir, { recursive: true, force: true });
+            }
+
+            fs.copyFileSync(shaders_dir + ss, out_dir + res[2]);
+        }
+    }
+}
+
+fs.writeFileSync(output, JSON.stringify(result, null, 2));

--- a/dist/reve/program_names.json
+++ b/dist/reve/program_names.json
@@ -1,0 +1,15 @@
+[
+  "custom_copyDepthToRed",
+  "custom_GBufferMini",
+  "custom_outline",
+  "custom_gaussBlur",
+  "custom_blendingAdditive",
+  "custom_ToneMapping",
+  "phong",
+  "basic",
+  "basic_zsprite",
+  "basic_stripes",
+  "custom_GBufferMini_stripes",
+  "custom_picker_TRIANGLES",
+  "custom_picker_POINTS"
+]

--- a/dist/reve/program_names.json
+++ b/dist/reve/program_names.json
@@ -1,4 +1,5 @@
 [
+  "custom_copyTexture",
   "custom_copyDepthToRed",
   "custom_GBufferMini",
   "custom_outline",

--- a/src/contrib/REveCameraControls.js
+++ b/src/contrib/REveCameraControls.js
@@ -1,0 +1,1052 @@
+/** Beased on THREE.OrbitCameraControls:
+ * @author qiao / https://github.com/qiao
+ * @author mrdoob / http://mrdoob.com
+ * @author alteredq / http://alteredqualia.com/
+ * @author WestLangley / http://github.com/WestLangley
+ * @author erich666 / http://erichaines.com
+ * @author ScieCode / http://github.com/sciecode
+ * and extended for ROOT-REve by
+ * @author osschar
+ * @author alja
+ */
+
+// This set of controls performs orbiting, dollying (zooming), and panning.
+// Unlike TrackballControls, it maintains the "up" direction object.up (+Y by default).
+//
+//    Orbit - left mouse / touch: one-finger move
+//    Zoom - middle mouse, or mousewheel / touch: two-finger spread or squish
+//    Pan - right mouse, or left mouse + ctrl/meta/shiftKey, or arrow keys / touch: two-finger move
+
+// Requires the following to be set on Camera passed.
+//   this.camera.isPerspectiveCamera = true;
+// or
+//   this.camera.isOrthographicCamera = true;
+
+import { EventDispatcher } from '../core/EventDispatcher.js';
+import { Vector3 } from '../math/Vector3.js';
+import { Vector2 } from '../math/Vector2.js';
+import { Quaternion } from '../math/Quaternion.js';
+import { Spherical } from '../math/Spherical.js';
+import { Matrix4 } from '../math/Matrix4.js';
+
+
+export class REveCameraControls extends EventDispatcher {
+
+	static matrixExtendDone = false;
+
+	constructor(object, domElement) {
+		var MOUSE = { ROTATE: 0, DOLLY: 1, PAN: 2 };
+		var TOUCH = { ROTATE: 0, PAN: 1, DOLLY_PAN: 2, DOLLY_ROTATE: 3 };
+
+		super(EventDispatcher);
+
+		if (!REveCameraControls.matrixExtendDone) {
+			ExtendRCMatrix();
+			REveCameraControls.matrixExtendDone = true;
+		}
+
+		this.object = object;
+
+		this.domElement = (domElement !== undefined) ? domElement : document;
+
+		// Set to false to disable this control
+		this.enabled = true;
+
+		// "target" sets the location of focus, where the object orbits around
+		this.target = new Vector3();
+		this.cameraCenter = new Vector3();
+
+		// How far you can dolly in and out ( PerspectiveCamera only )
+		this.minDistance = 0;
+		this.maxDistance = Infinity;
+
+		// How far you can zoom in and out ( OrthographicCamera only )
+		this.minZoom = 0;
+		this.maxZoom = Infinity;
+
+		// How far you can orbit vertically, upper and lower limits.
+		// Range is 0 to Math.PI radians.
+		this.minPolarAngle = 0; // radians
+		this.maxPolarAngle = Math.PI; // radians
+
+		// How far you can orbit horizontally, upper and lower limits.
+		// If set, must be a sub-interval of the interval [ - Math.PI, Math.PI ].
+		this.minAzimuthAngle = - Infinity; // radians
+		this.maxAzimuthAngle = Infinity; // radians
+
+		// Set to true to enable damping (inertia)
+		// If damping is enabled, you must call controls.update() in your animation loop
+		this.enableDamping = false;
+		this.dampingFactor = 0.05;
+
+		// This option actually enables dollying in and out; left as "zoom" for backwards compatibility.
+		// Set to false to disable zooming
+		this.enableZoom = true;
+		this.zoomSpeed = 1.0;
+
+		// Set to false to disable rotating
+		this.enableRotate = true;
+		this.rotateSpeed = 1.0;
+
+		// Set to false to disable panning
+		this.enablePan = true;
+		this.panSpeed = 1.0;
+		this.screenSpacePanning = false; // if true, pan in screen-space
+		this.keyPanSpeed = 7.0;	// pixels moved per arrow key push
+
+		// Set to true to automatically rotate around the target
+		// If auto-rotate is enabled, you must call controls.update() in your animation loop
+		this.autoRotate = false;
+		this.autoRotateSpeed = 2.0; // 30 seconds per round when fps is 60
+
+		// Set to false to disable use of the keys
+		this.enableKeys = true;
+
+		// The four arrow keys
+		this.keys = { LEFT: 37, UP: 38, RIGHT: 39, BOTTOM: 40 };
+
+		// Mouse buttons
+		this.mouseButtons = { LEFT: MOUSE.ROTATE, MIDDLE: MOUSE.DOLLY, RIGHT: MOUSE.PAN };
+
+		// Touch fingers
+		this.touches = { ONE: TOUCH.ROTATE, TWO: TOUCH.DOLLY_PAN };
+
+		// for reset
+		this.target0 = this.target.clone();
+		this.position0 = this.object.position.clone();
+		this.zoom0 = this.object.zoom;
+
+		//
+		// public methods
+		//
+		this.setCamBaseMtx = function(hAxis, vAxis)
+        {
+			camBase.identity();
+
+			camBase.setBaseVector(1, hAxis);
+			camBase.setBaseVector(3, vAxis);
+
+			let y = new Vector3();
+			y.crossVectors(vAxis, hAxis);
+			camBase.setBaseVector(2, y);
+		};
+
+		this.setFromBBox = function (bbox) {
+            let bb_center = new Vector3();
+			bbox.getCenter(bb_center);
+
+			let bb_R = Math.max(bbox.min.length(), bbox.max.length());
+
+			camTrans.identity();
+
+			if (this.object.isPerspectiveCamera) {
+				let fovDefault = 30;
+				let fov = Math.min(fovDefault, this.object.aspect*fovDefault);
+				let dollyDefault = bb_R / (2.0 * Math.tan(fov * Math.PI * 0.8/ 180));
+
+				camTrans.moveLF(1, dollyDefault);
+			}
+			else {
+                let dollyDefault  = 1.25*0.5*Math.sqrt(3)*bb_R;
+				camTrans.moveLF(1, dollyDefault);
+				scope.object.updateProjectionMatrix();
+			}
+		};
+
+		this.setCameraCenter = function (x, y, z) {
+			this.cameraCenter.set(x, y, z);
+
+			let bt = new Matrix4();
+			bt.multiplyMatrices(camBase, camTrans);
+			camBase.setBaseVector(4, this.cameraCenter);
+			let binv = camBase.clone();
+			binv.getInverse(camBase);
+			camTrans.multiplyMatrices(binv, bt);
+
+			if (this.centerMarker) {
+				this.centerMarker.position = this.cameraCenter;
+				this.centerMarker.visible = true;
+				this.centerMarker.updateMatrix();
+			}
+		};
+
+		this.getPolarAngle = function () {
+			return spherical.phi;
+		};
+
+		this.getAzimuthalAngle = function () {
+			return spherical.theta;
+		};
+
+		this.saveState = function () {
+			scope.target0.copy(scope.target);
+			scope.position0.copy(scope.object.position);
+			scope.zoom0 = scope.object.zoom;
+		};
+
+		this.reset = function () {
+			scope.target.copy(scope.target0);
+			scope.object.position.copy(scope.position0);
+			scope.object.zoom = scope.zoom0;
+
+			scope.object.updateProjectionMatrix();
+			scope.dispatchEvent(changeEvent);
+
+			scope.update();
+
+			state = STATE.NONE;
+		};
+
+		// osschar - need to reset internal panOffset
+		this.resetOrthoPanZoom = function () {
+			return function resetOrthoPan() {
+				panOffset.set(0, 0, 0);
+				scope.object.zoom = 0.78; // AMT default ortho camera zoom value in ROOT GL
+				scope.object.updateProjectionMatrix();
+				zoomChanged = true;
+			}
+		}();
+
+		// osschar - fake mouse up event, needed for context menu on M3 down
+		this.resetMouseDown = function (event) {
+			return function resetMouseDown(event) {
+				onMouseUp(event);
+			}
+		}();
+
+		this.testCameraMenu = function () {
+			return function testCameraMenu() {
+				dollyIn(0.5);
+			}
+		}();
+
+		/////////////////////////////////////////////////////////////////////////
+		////////////////////////////////////////////////////////////////////////
+		// alja - set camera matrix from two operations camBase and camTrans
+		this.update = function () {
+			var lastPosition = new Vector3();
+			var lastQuaternion = new Quaternion();
+			return function update() {
+				// dolly scale
+				if (scale != 1.0) {
+					let b1 = camTrans.getBaseVector(1);
+					let b4 = camTrans.getBaseVector(4);
+					let orig_dot = b1.dot(b4);
+					let lookAtDist = Math.sqrt(orig_dot);
+					let newMag = Math.sqrt(lookAtDist) * scale;
+					b4.multiplyScalar(scale);
+					camTrans.setBaseVector(4, b4);
+					scale = 1.0;
+
+					scope.object.near = Math.min(lookAtDist*0.1, 20);
+				}
+
+				// pan/ truck
+				if (panOffset.x || panOffset.y) {
+					camTrans.moveLF(2, panOffset.x);
+					camTrans.moveLF(3, panOffset.y);
+					panOffset.set(0, 0, 0);
+				}
+
+				let cam = new Matrix4();
+				cam.multiplyMatrices(camBase, camTrans);
+
+				// matrix needed to transform position from the picking
+				scope.object.testMtx = cam;
+
+				let eye = new Vector3(); eye.setFromMatrixPosition(cam);
+				let fwd = new Vector3(); fwd.setFromMatrixColumn(cam, 0);
+				let up = new Vector3(); up.setFromMatrixColumn(cam, 2);
+
+				/*
+				console.log("cam", cam, camBase, camTrans);
+				console.log("up", up.x, up.y, up.z);
+				console.log("fwd", fwd.x, fwd.y, fwd.z);
+				console.log("eye", eye.x, eye.y, eye.z);
+                */
+
+				scope.object._matrix.lookAtMt(eye, fwd, up);
+				scope.object._matrix.setPosition(eye);
+
+				// camera matrix auto update is disabled to prevent reading from quaternions
+				scope.object.matrixWorld.copy(scope.object.matrix);
+
+				// update condition is:
+				// min(camera displacement, camera rotation in radians)^2 > EPS
+				// using small-angle approximation
+
+				if (zoomChanged ||
+					lastPosition.distanceToSquared(cam.getBaseVector(4)) > EPS ||
+					10 * (sphericalDelta.phi + sphericalDelta.theta) > EPS) {
+
+					scope.dispatchEvent(changeEvent);
+
+					lastPosition.copy(cam.getBaseVector(4));
+					lastQuaternion.copy(scope.object.quaternion);
+					zoomChanged = false;
+
+					sphericalDelta.theta = 0;
+					sphericalDelta.phi = 0;
+
+					return true;
+				} else {
+					let dp = lastPosition.distanceToSquared(cam.getBaseVector(4));
+				}
+
+				//scope.dispatchEvent(changeEvent);
+
+				return true;
+			};
+		}();
+
+		this.dispose = function () {
+			scope.domElement.removeEventListener('contextmenu', onContextMenu, false);
+			scope.domElement.removeEventListener('mousedown', onMouseDown, false);
+			scope.domElement.removeEventListener('wheel', onMouseWheel, false);
+
+			scope.domElement.removeEventListener('touchstart', onTouchStart, false);
+			scope.domElement.removeEventListener('touchend', onTouchEnd, false);
+			scope.domElement.removeEventListener('touchmove', onTouchMove, false);
+
+			document.removeEventListener('mousemove', onMouseMove, false);
+			document.removeEventListener('mouseup', onMouseUp, false);
+
+			window.removeEventListener('keydown', onKeyDown, false);
+
+			//scope.dispatchEvent( { type: 'dispose' } ); // should this be added here?
+		};
+
+		//
+		// internals
+		//
+
+		var scope = this;
+
+		var changeEvent = { type: 'change' };
+		var startEvent = { type: 'start' };
+		var endEvent = { type: 'end' };
+
+		var STATE = {
+			NONE: - 1,
+			ROTATE: 0,
+			DOLLY: 1,
+			PAN: 2,
+			TOUCH_ROTATE: 3,
+			TOUCH_PAN: 4,
+			TOUCH_DOLLY_PAN: 5,
+			TOUCH_DOLLY_ROTATE: 6
+		};
+
+		var state = STATE.NONE;
+
+		var EPS = 0.000001;
+
+		// current position in spherical coordinates
+		var spherical = new Spherical();
+		var sphericalDelta = new Spherical();
+
+		var camBase = new Matrix4();
+		var camTrans = new Matrix4();
+
+		var scale = 1;
+		var panOffset = new Vector3();
+		var zoomChanged = false;
+
+		var rotateStart = new Vector2();
+		var rotateEnd = new Vector2();
+		var rotateDelta = new Vector2();
+
+		var panStart = new Vector2();
+		var panEnd = new Vector2();
+		var panDelta = new Vector2();
+
+		var dollyStart = new Vector2();
+		var dollyEnd = new Vector2();
+		var dollyDelta = new Vector2();
+
+		function getAutoRotationAngle() {
+			return 2 * Math.PI / 60 / 60 * scope.autoRotateSpeed;
+		}
+
+		function getZoomScale() {
+			return Math.pow(0.95, scope.zoomSpeed);
+		}
+
+		function rotateLeft(angle) {
+			sphericalDelta.theta -= angle;
+		}
+
+		function rotateUp(angle) {
+			sphericalDelta.phi -= angle;
+		}
+
+		function rotateRad(hRotate, vRotate) {
+			let fVAxisMinAngle = 0.01;
+			// console.log("rotate rad BEGIN hrotate = ", hRotate, ", vRotate = ", vRotate);
+
+			if (hRotate != 0.0) {
+				let fwd = camTrans.getBaseVector(1);
+				let lft = camTrans.getBaseVector(2);
+				let up = camTrans.getBaseVector(3);
+				let pos = camTrans.getTranslation();
+
+				let deltaF = pos.dot(fwd);
+				let deltaU = pos.dot(up);
+
+				// up vector lock
+				let zdir = camBase.getBaseVector(3);
+				camBase.rotateIP(fwd);
+				let theta = Math.acos(fwd.dot(zdir));
+				if (theta + hRotate < fVAxisMinAngle)
+					hRotate = fVAxisMinAngle - theta;
+				else if (theta + hRotate > Math.PI - fVAxisMinAngle)
+					hRotate = Math.PI - fVAxisMinAngle - theta;
+
+				camTrans.moveLF(1, -deltaF);
+				camTrans.moveLF(3, -deltaU);
+				camTrans.rotateLF(3, 1, hRotate);
+				camTrans.moveLF(3, deltaU);
+				camTrans.moveLF(1, deltaF);
+			}
+			if (vRotate != 0.0) {
+				camTrans.rotatePF(1, 2, -vRotate);
+			}
+
+			sphericalDelta.phi = hRotate;
+			sphericalDelta.theta = vRotate;
+		}
+
+		// deltaX and deltaY are in pixels; right and down are positive
+		var pan = function () {
+
+			var offset = new Vector3();
+
+			return function pan(deltaX, deltaY) {
+				// amt, x seem to be negatd
+				deltaX = -deltaX;
+
+				var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
+
+				if (scope.object.isPerspectiveCamera) {
+					// perspective
+					let targetDistance = 0.5 * (scope.object.far + scope.object.near) * Math.tan(0.5 * scope.object.fov * Math.PI / 180.0);
+					// we use only clientHeight here so aspect ratio does not distort speed
+					let h = deltaY * targetDistance / element.clientHeight;
+					let w = deltaX * targetDistance / element.clientHeight;
+					panOffset.setX(w);
+					panOffset.setY(h);
+				} else if (scope.object.isOrthographicCamera) {
+					// orthographic
+					panOffset.setX(deltaX * (scope.object.right - scope.object.left) / scope.object.zoom / element.clientWidth);
+					panOffset.setY(deltaY * (scope.object.top - scope.object.bottom) / scope.object.zoom / element.clientHeight);
+				} else {
+					// camera neither orthographic nor perspective
+					console.warn('WARNING: REveCameraControls encountered an unknown camera type - pan disabled.');
+					scope.enablePan = false;
+				}
+				scope.update();
+			};
+		}();
+
+		function dollyIn(dollyScale) {
+			if (scope.object.isPerspectiveCamera) {
+				scale /= dollyScale;
+			} else if (scope.object.isOrthographicCamera) {
+				scope.object.zoom = Math.max(scope.minZoom, Math.min(scope.maxZoom, scope.object.zoom * dollyScale));
+				scope.object.updateProjectionMatrix();
+				zoomChanged = true;
+			} else {
+				console.warn('WARNING: REveCameraControls encountered an unknown camera type - dolly/zoom disabled.');
+				scope.enableZoom = false;
+			}
+			scope.update();
+		}
+
+		function dollyOut(dollyScale) {
+			if (scope.object.isPerspectiveCamera) {
+				scale *= dollyScale;
+			} else if (scope.object.isOrthographicCamera) {
+				scope.object.zoom = Math.max(scope.minZoom, Math.min(scope.maxZoom, scope.object.zoom / dollyScale));
+				scope.object.updateProjectionMatrix();
+				zoomChanged = true;
+			} else {
+				console.warn('WARNING: REveCameraControls encountered an unknown camera type - dolly/zoom disabled.');
+				scope.enableZoom = false;
+			}
+
+			scope.update();
+		}
+
+		//
+		// event callbacks - update the object state
+		//
+
+		function handleMouseDownRotate(event) {
+			rotateStart.set(event.clientX, event.clientY);
+		}
+
+		function handleMouseDownDolly(event) {
+			dollyStart.set(event.clientX, event.clientY);
+		}
+
+		function handleMouseDownPan(event) {
+			panStart.set(event.clientX, event.clientY);
+		}
+
+		function handleMouseMoveRotate(event) {
+			rotateEnd.set(event.clientX, event.clientY);
+
+			rotateDelta.subVectors(rotateEnd, rotateStart).multiplyScalar(scope.rotateSpeed);
+
+			var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
+
+			rotateRad(-2 * Math.PI * rotateDelta.y / element.clientHeight, 2 * Math.PI * rotateDelta.x / element.clientWidth);
+
+			rotateStart.copy(rotateEnd);
+
+			scope.update();
+		}
+
+		function handleMouseMoveDolly(event) {
+			dollyEnd.set(event.clientX, event.clientY);
+
+			dollyDelta.subVectors(dollyEnd, dollyStart);
+
+			if (dollyDelta.y > 0) {
+				dollyIn(getZoomScale());
+			} else if (dollyDelta.y < 0) {
+				dollyOut(getZoomScale());
+			}
+
+			dollyStart.copy(dollyEnd);
+
+			scope.update();
+		}
+
+		function handleMouseMovePan(event) {
+			panEnd.set(event.clientX, event.clientY);
+			panDelta.subVectors(panEnd, panStart).multiplyScalar(scope.panSpeed);
+
+			pan(panDelta.x, panDelta.y);
+
+			panStart.copy(panEnd);
+
+			scope.update();
+		}
+
+		function handleMouseUp( /*event*/) {
+			// no-op
+		}
+
+		function handleMouseWheel(event) {
+			if (event.deltaY < 0) {
+				dollyOut(getZoomScale());
+			} else if (event.deltaY > 0) {
+				dollyIn(getZoomScale());
+			}
+
+			scope.update();
+		}
+
+		function handleKeyDown(event) {
+			var needsUpdate = false;
+
+			switch (event.keyCode) {
+				case scope.keys.UP:
+					pan(0, scope.keyPanSpeed);
+					needsUpdate = true;
+					break;
+
+				case scope.keys.BOTTOM:
+					pan(0, - scope.keyPanSpeed);
+					needsUpdate = true;
+					break;
+
+				case scope.keys.LEFT:
+					pan(scope.keyPanSpeed, 0);
+					needsUpdate = true;
+					break;
+
+				case scope.keys.RIGHT:
+					pan(- scope.keyPanSpeed, 0);
+					needsUpdate = true;
+					break;
+			}
+
+			if (needsUpdate) {
+				// prevent the browser from scrolling on cursor keys
+				event.preventDefault();
+				// and prevent others from consuming the event
+				event.stopImmediatePropagation();
+				scope.update();
+			}
+		}
+
+		function handleTouchStartRotate(event) {
+			if (event.touches.length == 1) {
+				rotateStart.set(event.touches[0].pageX, event.touches[0].pageY);
+			} else {
+				var x = 0.5 * (event.touches[0].pageX + event.touches[1].pageX);
+				var y = 0.5 * (event.touches[0].pageY + event.touches[1].pageY);
+				rotateStart.set(x, y);
+			}
+		}
+
+		function handleTouchStartPan(event) {
+			if (event.touches.length == 1) {
+				panStart.set(event.touches[0].pageX, event.touches[0].pageY);
+			} else {
+				var x = 0.5 * (event.touches[0].pageX + event.touches[1].pageX);
+				var y = 0.5 * (event.touches[0].pageY + event.touches[1].pageY);
+				panStart.set(x, y);
+			}
+		}
+
+		function handleTouchStartDolly(event) {
+			var dx = event.touches[0].pageX - event.touches[1].pageX;
+			var dy = event.touches[0].pageY - event.touches[1].pageY;
+			var distance = Math.sqrt(dx * dx + dy * dy);
+			dollyStart.set(0, distance);
+		}
+
+		function handleTouchStartDollyPan(event) {
+			if (scope.enableZoom) handleTouchStartDolly(event);
+			if (scope.enablePan) handleTouchStartPan(event);
+		}
+
+		function handleTouchStartDollyRotate(event) {
+			if (scope.enableZoom) handleTouchStartDolly(event);
+			if (scope.enableRotate) handleTouchStartRotate(event);
+		}
+
+		function handleTouchMoveRotate(event) {
+			if (event.touches.length == 1) {
+				rotateEnd.set(event.touches[0].pageX, event.touches[0].pageY);
+			} else {
+				var x = 0.5 * (event.touches[0].pageX + event.touches[1].pageX);
+				var y = 0.5 * (event.touches[0].pageY + event.touches[1].pageY);
+				rotateEnd.set(x, y);
+			}
+
+			rotateDelta.subVectors(rotateEnd, rotateStart).multiplyScalar(scope.rotateSpeed);
+
+			var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
+
+			rotateRad(-2 * Math.PI * rotateDelta.y / element.clientHeight, 2 * Math.PI * rotateDelta.x / element.clientWidth);
+
+			rotateStart.copy(rotateEnd);
+		}
+
+		function handleTouchMovePan(event) {
+			if (event.touches.length == 1) {
+				panEnd.set(event.touches[0].pageX, event.touches[0].pageY);
+			} else {
+				var x = 0.5 * (event.touches[0].pageX + event.touches[1].pageX);
+				var y = 0.5 * (event.touches[0].pageY + event.touches[1].pageY);
+				panEnd.set(x, y);
+			}
+
+			panDelta.subVectors(panEnd, panStart).multiplyScalar(scope.panSpeed);
+
+			pan(panDelta.x, panDelta.y);
+
+			panStart.copy(panEnd);
+		}
+
+		function handleTouchMoveDolly(event) {
+			var dx = event.touches[0].pageX - event.touches[1].pageX;
+			var dy = event.touches[0].pageY - event.touches[1].pageY;
+			var distance = Math.sqrt(dx * dx + dy * dy);
+
+			dollyEnd.set(0, distance);
+			dollyDelta.set(0, Math.pow(dollyEnd.y / dollyStart.y, scope.zoomSpeed));
+			dollyIn(dollyDelta.y);
+			dollyStart.copy(dollyEnd);
+		}
+
+		function handleTouchMoveDollyPan(event) {
+			if (scope.enableZoom) handleTouchMoveDolly(event);
+			if (scope.enablePan) handleTouchMovePan(event);
+		}
+
+		function handleTouchMoveDollyRotate(event) {
+			if (scope.enableZoom) handleTouchMoveDolly(event);
+			if (scope.enableRotate) handleTouchMoveRotate(event);
+		}
+
+		function handleTouchEnd( /*event*/) {
+			// no-op
+		}
+
+		//
+		// event handlers - FSM: listen for events and reset state
+		//
+
+		function onMouseDown(event) {
+			if (scope.enabled === false) return;
+
+			// Prevent the browser from scrolling.
+
+			event.preventDefault();
+
+			// Manually set the focus since calling preventDefault above
+			// prevents the browser from setting it automatically.
+
+			scope.domElement.focus ? scope.domElement.focus() : window.focus();
+
+			switch (event.button) {
+				case 0:
+					switch (scope.mouseButtons.LEFT) {
+						case MOUSE.ROTATE:
+							if (event.ctrlKey || event.metaKey || event.shiftKey) {
+								if (scope.enablePan === false) return;
+								handleMouseDownPan(event);
+								state = STATE.PAN;
+							} else {
+								if (scope.enableRotate === false) return;
+								handleMouseDownRotate(event);
+								state = STATE.ROTATE;
+							}
+							break;
+
+						case MOUSE.PAN:
+							if (event.ctrlKey || event.metaKey || event.shiftKey) {
+								if (scope.enableRotate === false) return;
+								handleMouseDownRotate(event);
+								state = STATE.ROTATE;
+							} else {
+								if (scope.enablePan === false) return;
+								handleMouseDownPan(event);
+								state = STATE.PAN;
+							}
+							break;
+
+						default:
+							state = STATE.NONE;
+					}
+					break;
+
+				case 1:
+					switch (scope.mouseButtons.MIDDLE) {
+						case MOUSE.DOLLY:
+							if (scope.enableZoom === false) return;
+							handleMouseDownDolly(event);
+							state = STATE.DOLLY;
+							break;
+
+						default:
+							state = STATE.NONE;
+					}
+					break;
+
+				case 2:
+					switch (scope.mouseButtons.RIGHT) {
+						case MOUSE.ROTATE:
+							if (scope.enableRotate === false) return;
+							handleMouseDownRotate(event);
+							state = STATE.ROTATE;
+							break;
+
+						case MOUSE.PAN:
+							if (scope.enablePan === false) return;
+							handleMouseDownPan(event);
+							state = STATE.PAN;
+							break;
+
+						default:
+							state = STATE.NONE;
+					}
+					break;
+			}
+
+			if (state !== STATE.NONE) {
+				document.addEventListener('mousemove', onMouseMove, false);
+				document.addEventListener('mouseup', onMouseUp, false);
+
+				scope.dispatchEvent(startEvent);
+			}
+		}
+
+		function onMouseMove(event) {
+			if (scope.enabled === false) return;
+
+			event.preventDefault();
+
+			switch (state) {
+				case STATE.ROTATE:
+					if (scope.enableRotate === false) return;
+					handleMouseMoveRotate(event);
+					break;
+
+				case STATE.DOLLY:
+					if (scope.enableZoom === false) return;
+					handleMouseMoveDolly(event);
+					break;
+
+				case STATE.PAN:
+					if (scope.enablePan === false) return;
+					handleMouseMovePan(event);
+					break;
+			}
+		}
+
+		function onMouseUp(event) {
+			if (scope.enabled === false) return;
+
+			handleMouseUp(event);
+
+			document.removeEventListener('mousemove', onMouseMove, false);
+			document.removeEventListener('mouseup', onMouseUp, false);
+
+			scope.dispatchEvent(endEvent);
+
+			state = STATE.NONE;
+		}
+
+		function onMouseWheel(event) {
+			if (scope.enabled === false || scope.enableZoom === false || (state !== STATE.NONE && state !== STATE.ROTATE)) return;
+
+			event.preventDefault();
+			event.stopPropagation();
+
+			scope.dispatchEvent(startEvent);
+
+			handleMouseWheel(event);
+
+			scope.dispatchEvent(endEvent);
+		}
+
+		function onKeyDown(event) {
+			if (scope.enabled === false || scope.enableKeys === false || scope.enablePan === false) return;
+
+			handleKeyDown(event);
+		}
+
+		function onTouchStart(event) {
+			if (scope.enabled === false) return;
+
+			event.preventDefault();
+
+			switch (event.touches.length) {
+				case 1:
+					switch (scope.touches.ONE) {
+						case TOUCH.ROTATE:
+							if (scope.enableRotate === false) return;
+							handleTouchStartRotate(event);
+							state = STATE.TOUCH_ROTATE;
+							break;
+
+						case TOUCH.PAN:
+							if (scope.enablePan === false) return;
+							handleTouchStartPan(event);
+							state = STATE.TOUCH_PAN;
+							break;
+
+						default:
+							state = STATE.NONE;
+					}
+					break;
+
+				case 2:
+					switch (scope.touches.TWO) {
+						case TOUCH.DOLLY_PAN:
+							if (scope.enableZoom === false && scope.enablePan === false) return;
+							handleTouchStartDollyPan(event);
+							state = STATE.TOUCH_DOLLY_PAN;
+							break;
+
+						case TOUCH.DOLLY_ROTATE:
+							if (scope.enableZoom === false && scope.enableRotate === false) return;
+							handleTouchStartDollyRotate(event);
+							state = STATE.TOUCH_DOLLY_ROTATE;
+							break;
+						default:
+							state = STATE.NONE;
+					}
+					break;
+
+				default:
+					state = STATE.NONE;
+
+			}
+
+			if (state !== STATE.NONE) {
+				scope.dispatchEvent(startEvent);
+			}
+		}
+
+		function onTouchMove(event) {
+
+			if (scope.enabled === false) return;
+
+			event.preventDefault();
+			event.stopPropagation();
+
+			switch (state) {
+				case STATE.TOUCH_ROTATE:
+					if (scope.enableRotate === false) return;
+					handleTouchMoveRotate(event);
+					scope.update();
+					break;
+
+				case STATE.TOUCH_PAN:
+					if (scope.enablePan === false) return;
+					handleTouchMovePan(event);
+					scope.update();
+					break;
+
+				case STATE.TOUCH_DOLLY_PAN:
+					if (scope.enableZoom === false && scope.enablePan === false) return;
+					handleTouchMoveDollyPan(event);
+					scope.update();
+					break;
+
+				case STATE.TOUCH_DOLLY_ROTATE:
+					if (scope.enableZoom === false && scope.enableRotate === false) return;
+					handleTouchMoveDollyRotate(event);
+					scope.update();
+					break;
+
+				default:
+					state = STATE.NONE;
+			}
+		}
+
+		function onTouchEnd(event) {
+			if (scope.enabled === false) return;
+
+			handleTouchEnd(event);
+
+			scope.dispatchEvent(endEvent);
+
+			state = STATE.NONE;
+		}
+
+		function onContextMenu(event) {
+			if (scope.enabled === false) return;
+
+			event.preventDefault();
+		}
+
+		function ExtendRCMatrix() {
+			Matrix4.prototype.lookAtMt = function (eye, fwd, up) {
+				var _x = new Vector3();
+				var _y = new Vector3();
+				var _z = new Vector3();
+				var te = this.elements;
+
+				_z.copy(fwd);
+				// _z.negate();
+				_z.normalize();
+				_x.crossVectors( up, _z );
+				_x.normalize();
+				_y.crossVectors( _z, _x );
+
+				te[ 0 ] = _x.x; te[ 4 ] = _y.x; te[ 8 ] = _z.x;
+				te[ 1 ] = _x.y; te[ 5 ] = _y.y; te[ 9 ] = _z.y;
+				te[ 2 ] = _x.z; te[ 6 ] = _y.z; te[ 10 ] = _z.z;
+
+				return this;
+			};
+
+			Matrix4.prototype.getBaseVector = function (idx) {
+				let off = 4 * --idx;
+				let C = this.elements;
+				return new Vector3(C[off + 0], C[off + 1], C[off + 2]);
+			};
+
+			Matrix4.prototype.getTranslation =  function () {
+				let C = this.elements;
+				return new Vector3(C[12], C[13], C[14]);
+			};
+
+			Matrix4.prototype.setBaseVector = function (idx, x, y, z) {
+				let off = 4 * --idx;
+				let C = this.elements;
+				if (x.isVector3) {
+					C[off + 0] = x.x; C[off + 1] = x.y; C[off + 2] = x.z;
+				}
+				else {
+					C[off + 0] = x; C[off + 1] = y; C[off + 2] = z;
+				}
+			};
+
+			Matrix4.prototype.rotateIP = function (v) {
+				let M = this.elements;
+				let r = v.clone();
+				v.x = M[0] * r.x + M[4] * r.y + M[8] * r.z;
+				v.y = M[1] * r.x + M[5] * r.y + M[9] * r.z;
+				v.z = M[2] * r.x + M[6] * r.y + M[10] * r.z;
+			};
+
+			Matrix4.prototype.rotateLF = function (i1, i2, amount) {
+				if (i1 == i2) return;
+
+				let cos = Math.cos(amount); let sin = Math.sin(amount);
+				let b1; let b2;
+				let C = this.elements;
+				i1 = (i1 - 1) * 4;
+				i2 = (i2 - 1) * 4; // column major
+				let off = 0;
+				for (let r = 0; r < 4; ++r, ++off) {
+					b1 = cos * C[i1 + off] + sin * C[i2 + off];
+					b2 = cos * C[i2 + off] - sin * C[i1 + off];
+					C[i1 + off] = b1; C[i2 + off] = b2;
+				}
+			};
+
+			Matrix4.prototype.rotatePF = function (i1, i2, amount) {
+				if (i1 == i2) return;
+
+				let cos = Math.cos(amount); let sin = Math.sin(amount);
+				let b1; let b2;
+				let C = this.elements;
+				--i1; --i2;
+				for (let c = 0; c < 4; ++c) {
+					let off = c * 4;
+					b1 = cos * C[i1 + off] - sin * C[i2 + off];
+					b2 = cos * C[i2 + off] + sin * C[i1 + off];
+					C[i1 + off] = b1; C[i2 + off] = b2;
+				}
+			};
+
+			Matrix4.prototype.moveLF = function (ai, amount) {
+				let C = this.elements; let off = 4 * (ai - 1);
+				C[12] += amount * C[off];
+				C[13] += amount * C[off + 1];
+				C[14] += amount * C[off + 2];
+			};
+
+			Matrix4.prototype.dump = function () {
+				for (let x = 0; x < 4; x++) {
+					let row = "[ ";
+					for (let y = 0; y < 4; y++) {
+						let val = this.elements[y * 4 + x].toFixed(2);
+						row += val; row += " ";
+					}
+					console.log(row + "]");
+				}
+			}
+		}
+
+		scope.domElement.addEventListener('contextmenu', onContextMenu, false);
+
+		scope.domElement.addEventListener('mousedown', onMouseDown, false);
+		scope.domElement.addEventListener('wheel', onMouseWheel, false);
+
+		scope.domElement.addEventListener('touchstart', onTouchStart, false);
+		scope.domElement.addEventListener('touchend', onTouchEnd, false);
+		scope.domElement.addEventListener('touchmove', onTouchMove, false);
+
+		scope.domElement.addEventListener('mouseenter', function (event) {
+			window.addEventListener('keydown', onKeyDown);
+		});
+		scope.domElement.addEventListener('mouseleave', function (event) {
+			window.removeEventListener('keydown', onKeyDown);
+		});
+
+		// force an update at start
+
+		this.update();
+	}
+};

--- a/src/contrib/REveRenderCore.js
+++ b/src/contrib/REveRenderCore.js
@@ -1,12 +1,6 @@
 /**
  * Reduced RenderCore for ROOT-REve.
- *
- * /opt/npm/bin/rollup REveRenderCore.js --format es --file REveRenderCore.mjs
- * /opt/npm/bin/uglifyjs REveRenderCore.mjs -c -b indent_level=1 -m -o REveRenderCore-min.mjs
- * tar cf RenderCore.tar REveRenderCore-min.mjs ../shaders/
- * gzip -9 RenderCore.tar
- * sha256sum -b RenderCore.tar.gz
- * mv RenderCore.tar.gz ROOT-SRC/builtins/rendercore/
+ * See dist/reve/Makefile for further packing procedure.
  */
 
 // Constants
@@ -61,7 +55,7 @@ export {GLAttributeManager} from '../core/GLAttributeManager.js';
 export {GLFrameBufferManager} from '../core/GLFrameBufferManager.js';
 export {GLTextureManager} from '../core/GLTextureManager.js';
 export {GLManager} from '../core/GLManager.js';
-// export {Canvas} from '../core/Canvas.js';
+export {Canvas} from '../core/Canvas.js';
 // export {CanvasManager} from '../core/CanvasManager.js';
 export {Object3D} from '../core/Object3D.js';
 export {Raycaster} from '../core/Raycaster.js';

--- a/src/contrib/REveRenderCore.js
+++ b/src/contrib/REveRenderCore.js
@@ -1,0 +1,186 @@
+/**
+ * Reduced RenderCore for ROOT-REve.
+ *
+ * /opt/npm/bin/rollup REveRenderCore.js --format es --file REveRenderCore.mjs
+ * /opt/npm/bin/uglifyjs REveRenderCore.mjs -c -b indent_level=1 -m -o REveRenderCore-min.mjs
+ * tar cf RenderCore.tar REveRenderCore-min.mjs ../shaders/
+ * gzip -9 RenderCore.tar
+ * sha256sum -b RenderCore.tar.gz
+ * mv RenderCore.tar.gz ROOT-SRC/builtins/rendercore/
+ */
+
+// Constants
+export * from '../constants.js';
+
+// Math
+// export {QuaternionLinearInterpolant} from '../math/interpolants/QuaternionLinearInterpolant.js';
+// export {LinearInterpolant} from '../math/interpolants/LinearInterpolant.js';
+// export {DiscreteInterpolant} from '../math/interpolants/DiscreteInterpolant.js';
+// export {CubicInterpolant} from '../math/interpolants/CubicInterpolant.js';
+// export {Interpolant} from '../math/Interpolant.js';
+export {Triangle} from '../math/Triangle.js';
+export {_Math} from '../math/Math.js';
+export {Spherical} from '../math/Spherical.js';
+export {Cylindrical} from '../math/Cylindrical.js';
+export {Plane} from '../math/Plane.js';
+export {Frustum} from '../math/Frustum.js';
+export {Sphere} from '../math/Sphere.js';
+export {Ray} from '../math/Ray.js';
+export {Matrix4} from '../math/Matrix4.js';
+export {Matrix3} from '../math/Matrix3.js';
+export {Box3} from '../math/Box3.js';
+export {Box2} from '../math/Box2.js';
+export {Line3} from '../math/Line3.js';
+export {Euler} from '../math/Euler.js';
+export {Vector4} from '../math/Vector4.js';
+export {Vector3} from '../math/Vector3.js';
+export {Vector2} from '../math/Vector2.js';
+export {Quaternion} from '../math/Quaternion.js';
+export {Color} from '../math/Color.js';
+// export {SphericalHarmonics3} from '../math/SphericalHarmonics3.js';
+
+// Loaders
+export {Cache} from '../loaders/Cache.js';
+export {ImageCache, TextureCache} from '../loaders/ImageCache.js';
+export {LoadingManager} from '../loaders/LoadingManager.js';
+export {XHRLoader} from '../loaders/XHRLoader.js';
+export {ShaderLoader} from '../loaders/ShaderLoader.js';
+// export {ObjLoader} from '../loaders/ObjLoader.js';
+// export {ImageLoader} from '../loaders/ImageLoader.js';
+// export {MHDReader} from '../loaders/MHDReader.js';
+// export {RAWLoader} from '../loaders/RAWLoader.js';
+// export {XHRStreamer} from '../loaders/XHRStreamer.js';
+// export {LASLoader} from '../loaders/LASLoader.js';
+
+// Online Interaction
+export {UpdateListener} from '../online_interaction/UpdateListener.js';
+
+// Core
+export * from '../core/BufferAttribute.js';
+export {GLAttributeManager} from '../core/GLAttributeManager.js';
+export {GLFrameBufferManager} from '../core/GLFrameBufferManager.js';
+export {GLTextureManager} from '../core/GLTextureManager.js';
+export {GLManager} from '../core/GLManager.js';
+// export {Canvas} from '../core/Canvas.js';
+// export {CanvasManager} from '../core/CanvasManager.js';
+export {Object3D} from '../core/Object3D.js';
+export {Raycaster} from '../core/Raycaster.js';
+export {Scene} from '../core/Scene.js';
+// export {SceneManager} from '../core/SceneManager.js';
+export {EventDispatcher} from '../core/EventDispatcher.js';
+
+// Cameras
+export {Camera} from '../cameras/Camera.js';
+export {PerspectiveCamera} from '../cameras/PerspectiveCamera.js';
+export {OrthographicCamera} from '../cameras/OrthographicCamera.js';
+// export {CameraFactory} from '../cameras/CameraFactory.js';
+// export {OrbitCameraControls} from '../cameras/OrbitCameraControls.js';
+// export {FullOrbitCameraControls} from '../cameras/FullOrbitCameraControls.js';
+// export {RegularCameraControls} from '../cameras/RegularCameraControls.js';
+// export {CameraManager} from '../cameras/CameraManager.js';
+// export {XRCamera} from '../cameras/XRCamera.js';
+// export {XRPerspectiveCamera} from '../cameras/XRPerspectiveCamera.js';
+// export {XROrthographicCamera} from '../cameras/XROrthographicCamera.js';
+
+// Lights
+export {Light} from '../lights/Light.js';
+export {AmbientLight} from '../lights/AmbientLight.js';
+export {DirectionalLight} from '../lights/DirectionalLight.js';
+export {PointLight} from '../lights/PointLight.js';
+export {SpotLight} from '../lights/SpotLight.js';
+
+// Texture
+export {Texture} from '../textures/Texture.js';
+export {CubeTexture} from '../textures/CubeTexture.js';
+
+// Materials
+export {Material} from '../materials/Material.js'
+export {MeshBasicMaterial} from '../materials/MeshBasicMaterial.js'
+export {MeshLambertMaterial} from '../materials/MeshLambertMaterial.js';
+export {MeshPhongMaterial} from '../materials/MeshPhongMaterial.js';
+export {CustomShaderMaterial} from '../materials/CustomShaderMaterial.js';
+// export {VolumeBasicMaterial} from '../materials/VolumeBasicMaterial.js';
+export {SpriteBasicMaterial} from '../materials/SpriteBasicMaterial.js';
+export {PickingShaderMaterial} from '../materials/PickingShaderMaterial.js';
+export {StripeBasicMaterial} from '../materials/StripeBasicMaterial.js';
+export {StripesBasicMaterial} from '../materials/StripesBasicMaterial.js';
+export {PointBasicMaterial} from '../materials/PointBasicMaterial.js';
+export {Text2DMaterial} from '../materials/Text2DMaterial.js';
+// export {SkyBox2BasicMaterial} from '../materials/SkyBox2BasicMaterial.js';
+// export {DirectionalShadowMaterial} from '../materials/DirectionalShadowMaterial.js';
+// export {PointShadowMaterial} from '../materials/PointShadowMaterial.js';
+// export {VertexNormalMaterial} from '../materials/VertexNormalMaterial.js';
+
+// Objects
+export {Geometry} from '../objects/Geometry.js';
+export {Mesh} from '../objects/Mesh.js';
+export {Circle} from '../objects/Circle.js';
+// export {Contour} from '../objects/Contour.js';
+export {Cube} from '../objects/Cube.js';
+// export {GeoidSphere} from '../objects/GeoidSphere.js';
+// export {IcoSphere} from '../objects/IcoSphere.js';
+export {Group} from '../objects/Group.js';
+export {Line} from '../objects/Line.js';
+export {Quad} from '../objects/Quad.js';
+// export {TerrainPlane} from '../objects/TerrainPlane.js';
+// export {Volume} from '../objects/Volume.js';
+// export {PointCloud} from '../objects/PointCloud.js';
+export {Sprite} from '../objects/Sprite.js';
+export {SpriteGeometry} from '../objects/SpriteGeometry.js';
+// export {Cone} from '../objects/Cone.js';
+// export {ConeGeometry} from '../objects/ConeGeometry.js';
+// export {SkyBox} from '../objects/SkyBox.js';
+// export {SkyBox2} from '../objects/SkyBox2.js';
+// export {SkyDome} from '../objects/SkyDome.js'
+export {Point} from '../objects/Point.js';
+export {Stripe} from '../objects/Stripe.js';
+export {Stripes} from '../objects/Stripes.js';
+export {StripesGeometry} from '../objects/StripesGeometry.js';
+// export {VertexNormal} from '../objects/VertexNormal.js';
+export {Text2D} from '../objects/Text2D.js';
+export {Grid} from '../objects/Grid.js';
+
+// Instanced, instance-pickable, outline-supporting materials and objects
+export {ZSpriteBasicMaterial} from '../materials/ZSpriteBasicMaterial.js';
+export {ZSprite} from '../objects/ZSprite.js';
+
+// Program Management
+export {MaterialProgramTemplate} from '../program_management/MaterialProgramTemplate.js';
+export {GLProgramManager} from '../program_management/GLProgramManager.js';
+export {GLProgram} from '../program_management/GLProgram.js';
+export {ShaderBuilder} from '../program_management/ShaderBuilder.js';
+
+// Renderers
+export {Renderer} from '../renderers/Renderer.js';
+export {RenderTarget} from '../renderers/RenderTarget.js';
+export {RenderPass} from '../renderers/RenderPass.js';
+export {RenderQueue} from '../renderers/RenderQueue.js';
+export {MeshRenderer} from '../renderers/MeshRenderer.js';
+// export {VolumeRenderer} from '../renderers/VolumeRenderer.js';
+// export {RendererManager} from '../renderers/RendererManager.js';
+// export {RenderQueueManager} from '../renderers/RenderQueueManager.js';
+export {RenderArray} from '../renderers/RenderArray.js';
+export {RenderArrayManager} from '../renderers/RenderArrayManager.js';
+// export {FX} from '../renderers/FX/FX.js';
+// export {BloomFX} from '../renderers/FX/BloomFX.js';
+// export {VolumetricLightFX} from '../renderers/FX/VolumetricLightFX.js';
+// export {SSAOFX} from '../renderers/FX/SSAOFX.js';
+// export {SSAAFX} from '../renderers/FX/SSAAFX.js';
+// export {FogFX} from '../renderers/FX/FogFX.js';
+// export {OutlineFX} from '../renderers/FX/OutlineFX.js';
+// export {FXAAFX} from '../renderers/FX/FXAAFX.js';
+// export {PickerFX} from '../renderers/FX/PickerFX.js';
+// export {ToneMapperFX} from '../renderers/FX/ToneMapperFX.js';
+// export {ShadowMapFX} from '../renderers/FX/ShadowMapFX.js';
+// export {DoFFX} from '../renderers/FX/DoFFX.js';
+
+// Controls (Input)
+// export {KeyboardInput} from '../controls/KeyboardInput.js';
+// export {MouseInput} from '../controls/MouseInput.js';
+// export {GamepadInput} from '../controls/GamepadInput.js';
+
+// ------------------------------------------------------------
+// REve specifics
+
+export {RendeQuTor} from './RendeQuTor.js';
+export {REveCameraControls} from './REveCameraControls.js';

--- a/src/contrib/RendeQuTor.js
+++ b/src/contrib/RendeQuTor.js
@@ -49,7 +49,8 @@ export class RendeQuTor
 
         this.make_RP_GaussHVandBlend();
 
-        // this.make_RP_ToScreen();
+        // Only one of the next two gets called from the driver.
+        this.make_RP_ToScreen();
         this.make_RP_ToneMapToScreen();
 
         this.RP_GBuffer.obj_list = [];
@@ -59,6 +60,7 @@ export class RendeQuTor
             this.RP_Outline_mat.requiredProgram(this.renderer),
             this.RP_GaussH_mat.requiredProgram(this.renderer),
             this.RP_Blend_mat.requiredProgram(this.renderer),
+            this.RP_ToScreen_mat.requiredProgram(this.renderer),
             this.RP_ToneMapToScreen_mat.requiredProgram(this.renderer)
           ]);
     }
@@ -186,6 +188,19 @@ export class RendeQuTor
         this.RP_ToneMapToScreen.input_texture = this.tex_final;
 
         this.queue.render_pass(this.RP_ToneMapToScreen, "Tone Map To Screen");
+
+        if (this.tex_final_push) {
+            this.push_std_texture(this.tex_final);
+            this.tex_final = null;
+            this.tex_final_push = null;
+        }
+    }
+
+    render_final_to_screen()
+    {
+        this.RP_ToScreen.input_texture = this.tex_final;
+
+        this.queue.render_pass(this.RP_ToScreen, "Copy Final To Screen");
 
         if (this.tex_final_push) {
             this.push_std_texture(this.tex_final);

--- a/src/contrib/RendeQuTor.js
+++ b/src/contrib/RendeQuTor.js
@@ -1,0 +1,721 @@
+import {RenderQueue} from '../renderers/RenderQueue.js';
+import {RenderPass}  from '../renderers/RenderPass.js';
+import {CustomShaderMaterial} from '../materials/CustomShaderMaterial.js';
+import {FRONT_AND_BACK_SIDE, HIGHPASS_MODE_BRIGHTNESS, HIGHPASS_MODE_DIFFERENCE}
+    from '../constants.js';
+
+export class RendeQuTor
+{
+    constructor(renderer, scene, camera)
+    {
+        this.renderer = renderer;
+        this.scene    = scene;
+        this.camera   = camera;
+        this.queue    = new RenderQueue(renderer);
+        this.pqueue   = new RenderQueue(renderer);
+        this.vp_w = 0;
+        this.vp_h = 0;
+        this.pick_radius = 32;
+        this.pick_center = 16;
+
+        this.make_PRP_plain();
+        this.make_PRP_depth2r();
+        this.renderer.preDownloadPrograms(
+          [ this.PRP_depth2r_mat.requiredProgram(this.renderer)
+          ]);
+
+          this.SSAA_value = 1;
+
+        this.clear_zero_f32arr = new Float32Array([0,0,0,0]);
+
+        this.std_textures = [];
+        this.std_tex_cnt  = 0;
+        this.std_tex_used = new Set();
+    }
+
+    initDirectToScreen()
+    {
+        this.make_RP_DirectToScreen();
+    }
+
+    initSimple(ssaa_val)
+    {
+        this.SSAA_value = ssaa_val;
+
+        this.make_RP_SSAA_Super();
+
+        this.make_RP_GBuffer();
+        this.make_RP_Outline();
+
+        this.make_RP_GaussHVandBlend();
+
+        // this.make_RP_ToScreen();
+        this.make_RP_ToneMapToScreen();
+
+        this.RP_GBuffer.obj_list = [];
+
+        this.renderer.preDownloadPrograms(
+          [ this.RP_GBuffer_mat.requiredProgram(this.renderer),
+            this.RP_Outline_mat.requiredProgram(this.renderer),
+            this.RP_GaussH_mat.requiredProgram(this.renderer),
+            this.RP_Blend_mat.requiredProgram(this.renderer),
+            this.RP_ToneMapToScreen_mat.requiredProgram(this.renderer)
+          ]);
+    }
+
+    initFull(ssaa_val)
+    {
+        this.SSAA_value = ssaa_val;
+
+        this.make_RP_SSAA_Super();
+        this.make_RP_HighPassGaussBloom();
+        // this.make_RP_SSAA_Down(); this.RP_SSAA_Down.input_texture = "color_bloom";
+        this.make_RP_ToScreen();
+        this.RP_ToScreen.input_texture = "color_bloom";
+    }
+
+    updateViewport(w, h)
+    {
+        this.vp_w = w;
+        this.vp_h = h;
+        let vp = { width: w, height: h };
+        let rq = this.queue._renderQueue;
+        for (let i = 0; i < rq.length; i++)
+        {
+            rq[i].view_setup(vp);
+        }
+        // Picking render-passes stay constant.
+    }
+
+    //=============================================================================
+
+    pop_std_texture() {
+        let tex;
+        if (this.std_textures.length == 0) {
+            tex = "std_tex_" + this.std_tex_cnt++;
+        } else {
+            tex = this.std_textures.pop();
+        }
+        this.std_tex_used.add(tex);
+        return tex;
+    }
+
+    push_std_texture(tex) {
+        this.std_tex_used.delete(tex);
+        this.std_textures.push(tex);
+    }
+
+    release_std_textures() {
+        if (this.std_tex_used.size > 0) {
+            // console.log("RendeQuTor releasing std textures", this.std_tex_used.size);
+            for (const tex of this.std_tex_used)
+                this.std_textures.push(tex);
+            this.std_tex_used.clear();
+        }
+    }
+
+    // ----------
+
+    render_outline()
+    {
+        let tex_normal = this.pop_std_texture();
+        let tex_view_dir = this.pop_std_texture();
+        this.RP_GBuffer.outTextures[0].id = tex_normal;
+        this.RP_GBuffer.outTextures[1].id = tex_view_dir;
+
+        this.queue.render_pass(this.RP_GBuffer, "GBuffer");
+
+        this.RP_Outline.intex_normal = tex_normal;
+        this.RP_Outline.intex_view_dir = tex_view_dir;
+        if ( ! this.tex_outline) {
+            // First outline, get the texture to accumulate all outlines
+            this.tex_outline = this.pop_std_texture();
+        } else {
+            // Additional outlines, do not clear the accumulatortexture.
+            this.RP_Outline.outTextures[0].clearColorArray = null;
+        }
+        this.RP_Outline.outTextures[0].id = this.tex_outline;
+
+        this.queue.render_pass(this.RP_Outline, "Outline");
+
+        this.push_std_texture(tex_normal);
+        this.push_std_texture(tex_view_dir);
+    }
+
+    render_main_and_blend_outline()
+    {
+        let main_is_std = (this.SSAA_value == 1);
+        let tex_main = main_is_std ? this.pop_std_texture() : "color_main";
+
+        this.RP_SSAA_Super.outTextures[0].id = tex_main;
+        this.queue.render_pass(this.RP_SSAA_Super, "SSAA Super");
+
+        if (this.tex_outline) {
+            let tA = this.tex_outline;
+            let tB = this.pop_std_texture();
+
+            this.RP_GaussH.intex = tA;
+            this.RP_GaussH.outTextures[0].id = tB;
+            this.queue.render_pass(this.RP_GaussH, "GaussH");
+
+            this.RP_GaussV.intex = tB;
+            this.RP_GaussV.outTextures[0].id = tA;
+            this.queue.render_pass(this.RP_GaussV, "GaussV");
+
+            this.RP_Blend.intex_outline_blurred = tA;
+            this.RP_Blend.intex_main = tex_main;
+            this.RP_Blend.outTextures[0].id = tB;
+            this.queue.render_pass(this.RP_Blend, "Blend");
+
+            if (main_is_std) this.push_std_texture(tex_main);
+
+            this.push_std_texture(this.tex_outline);
+            this.RP_Outline.outTextures[0].clearColorArray = this.clear_zero_f32arr;
+            this.tex_outline = null;
+
+            this.tex_final = tB;
+            this.tex_final_push = true;
+        } else {
+            this.tex_final = tex_main;
+            this.tex_final_push = main_is_std;
+        }
+    }
+
+    render_tone_map_to_screen()
+    {
+        this.RP_ToneMapToScreen.input_texture = this.tex_final;
+
+        this.queue.render_pass(this.RP_ToneMapToScreen, "Tone Map To Screen");
+
+        if (this.tex_final_push) {
+            this.push_std_texture(this.tex_final);
+            this.tex_final = null;
+            this.tex_final_push = null;
+        }
+    }
+
+    render_begin(used_check)
+    {
+        this.tex_outline = null;
+
+        this.queue.render_begin(used_check);
+    }
+
+    render_end()
+    {
+        this.queue.render_end();
+        this.release_std_textures();
+    }
+
+    // ----------
+
+    render()
+    {
+        // This can work for setups without outline passes -- once they are
+        // brought back to life.
+
+        this.queue.render();
+    }
+
+    //=============================================================================
+
+    pick_begin(x, y)
+    {
+        this.camera.prePickStoreTBLR();
+        this.camera.narrowProjectionForPicking(this.vp_w, this.vp_h,
+                                               this.pick_radius, this.pick_radius,
+                                               x, this.vp_h - 1 - y);
+    }
+
+    pick_end()
+    {
+        this.camera.postPickRestoreTBLR();
+    }
+
+    pick(x, y, detect_depth = false)
+    {
+        this.renderer.pick_setup(this.pick_center, this.pick_center);
+
+        let state = this.pqueue.render();
+        state.x = x;
+        state.y = y;
+        state.depth = -1.0;
+        state.object = this.renderer.pickedObject3D;
+        // console.log("RenderQuTor::pick", state);
+
+        if (detect_depth && this.renderer.pickedObject3D !== null)
+        {
+            let rdr = this.renderer;
+            let gl  = rdr.gl;
+            let fbm = rdr.glManager._fboManager;
+
+            fbm.bindFramebuffer(this.pqueue._renderTarget);
+
+            let d = new Float32Array(9);
+            gl.readBuffer(gl.COLOR_ATTACHMENT0);
+            gl.readPixels(this.pick_center - 1, this.pick_center - 1, 3, 3, gl.RED, gl.FLOAT, d);
+
+            fbm.unbindFramebuffer();
+
+            let near = this.camera.near;
+            let far  = this.camera.far;
+            for (let i = 0; i < 9; ++i)
+                d[i] = (near * far) / ((near - far) * d[i] + far);
+            state.depth = d[4];
+            // console.log("    pick depth at", x, ",", y, ":", d);
+        }
+
+        return state;
+    }
+
+    pick_instance(state)
+    {
+        if (state.object !== this.renderer.pickedObject3D) {
+            console.error("RendeQuTor::pick_instance state mismatch", state, this.renderer.pickedObject3D);
+        } else {
+            // console.log("RenderQuTor::pick_instance going for secondary select");
+
+            this.renderer._pickSecondaryEnabled = true;
+            this.pqueue.render();
+
+            state.instance = this.renderer._pickedID;
+        }
+        return state;
+    }
+
+
+    //=============================================================================
+    // Picking RenderPasses
+    //=============================================================================
+
+    make_PRP_plain()
+    {
+        let pthis = this;
+
+        this.PRP_plain = new RenderPass(
+            RenderPass.BASIC,
+            function (textureMap, additionalData) {},
+            function (textureMap, additionalData) {
+                return { scene: pthis.scene, camera: pthis.camera };
+            },
+            function (textureMap, additionalData) {},
+            RenderPass.TEXTURE,
+            { width: this.pick_radius, height: this.pick_radius },
+            "depth_picking",
+            [ { id: "color_picking", textureConfig: RenderPass.DEFAULT_R32UI_TEXTURE_CONFIG,
+                clearColorArray: new Uint32Array([0xffffffff, 0, 0, 0]) } ]
+        );
+
+        this.pqueue.pushRenderPass(this.PRP_plain);
+    }
+
+    make_PRP_depth2r()
+    {
+        this.PRP_depth2r_mat = new CustomShaderMaterial("copyDepthToRed");
+        this.PRP_depth2r_mat.lights = false;
+        let pthis = this;
+
+        this.PRP_depth2r = new RenderPass(
+            RenderPass.POSTPROCESS,
+            function (textureMap, additionalData) {},
+            function (textureMap, additionalData) {
+                return { material: pthis.PRP_depth2r_mat, textures: [ textureMap["depth_picking"] ] };
+            },
+            function (textureMap, additionalData) {},
+            RenderPass.TEXTURE,
+            { width: this.pick_radius, height: this.pick_radius },
+            null,
+            [ { id: "depthr32f_picking", textureConfig: RenderPass.FULL_FLOAT_R32F_TEXTURE_CONFIG,
+                clearColorArray: new Float32Array([1, 0, 0, 0]) } ]
+        );
+
+        this.pqueue.pushRenderPass(this.PRP_depth2r);
+    }
+
+
+    //=============================================================================
+    // Regular RenderPasses
+    //=============================================================================
+
+    make_RP_DirectToScreen()
+    {
+        let pthis = this;
+
+        this.RP_DirectToScreen = new RenderPass(
+            RenderPass.BASIC,
+            function (textureMap, additionalData) {},
+            function (textureMap, additionalData) { return { scene: pthis.scene, camera: pthis.camera }; },
+            function (textureMap, additionalData) {},
+            RenderPass.SCREEN,
+            null
+        );
+        this.RP_DirectToScreen.view_setup = function (vport) { this.viewport = vport; };
+
+        this.queue.pushRenderPass(this.RP_DirectToScreen);
+    }
+
+    //=============================================================================
+
+    make_RP_SSAA_Super()
+    {
+        let pthis = this;
+
+        this.RP_SSAA_Super = new RenderPass(
+            // Rendering pass type
+            RenderPass.BASIC,
+            // Initialize function
+            function (textureMap, additionalData) {},
+            // Preprocess function
+            function (textureMap, additionalData) { return { scene: pthis.scene, camera: pthis.camera }; },
+            // Postprocess
+            function (textureMap, additionalData) {},
+            // Target
+            RenderPass.TEXTURE,
+            // Viewport
+            null,
+            // Bind depth texture to this ID
+            "depth_main",
+            // Outputs
+            [ { id: "color_main", textureConfig: RenderPass.DEFAULT_RGBA16F_TEXTURE_CONFIG } ]
+        );
+        this.RP_SSAA_Super.view_setup = function (vport) { this.viewport = { width: vport.width*pthis.SSAA_value, height: vport.height*pthis.SSAA_value }; };
+
+        this.queue.pushRenderPass(this.RP_SSAA_Super);
+    }
+
+    make_RP_SSAA_Down()
+    {
+        this.RP_SSAA_Down_mat = new CustomShaderMaterial("copyTexture");
+        this.RP_SSAA_Down_mat.lights = false;
+        let pthis = this;
+
+        this.RP_SSAA_Down = new RenderPass(
+            // Rendering pass type
+            RenderPass.POSTPROCESS,
+
+            // Initialize function
+            function (textureMap, additionalData) {},
+            // Preprocess function
+            function (textureMap, additionalData) {
+                return { material: pthis.RP_SSAA_Down_mat, textures: [textureMap[this.input_texture]] };
+            },
+            // Postprocess function
+            function (textureMap, additionalData) {},
+
+            // Target
+            RenderPass.TEXTURE,
+
+            // Viewport
+            null,
+
+            // Bind depth texture to this ID
+            null,
+
+            [ { id: "color_main", textureConfig: RenderPass.DEFAULT_RGBA16F_TEXTURE_CONFIG } ]
+        );
+        this.RP_SSAA_Down.input_texture = "color_super";
+        this.RP_SSAA_Down.view_setup = function(vport) { this.viewport = vport; };
+
+        this.queue.pushRenderPass(this.RP_SSAA_Down);
+    }
+
+    //=============================================================================
+
+    make_RP_ToScreen()
+    {
+        this.RP_ToScreen_mat = new CustomShaderMaterial("copyTexture");
+        this.RP_ToScreen_mat.lights = false;
+        let pthis = this;
+
+        this.RP_ToScreen = new RenderPass(
+            RenderPass.POSTPROCESS,
+            function (textureMap, additionalData) {},
+            function (textureMap, additionalData) {
+                return { material: pthis.RP_ToScreen_mat, textures: [ textureMap[this.input_texture] ] };
+            },
+            function (textureMap, additionalData) {},
+            RenderPass.SCREEN,
+            null
+        );
+        this.RP_ToScreen.input_texture = "color_main";
+        this.RP_ToScreen.view_setup = function(vport) { this.viewport = vport; };
+
+        this.queue.pushRenderPass(this.RP_ToScreen);
+    }
+
+    make_RP_ToneMapToScreen()
+    {
+        this.RP_ToneMapToScreen_mat = new CustomShaderMaterial("ToneMapping",
+            { MODE: 1.0, gamma: 1.0, exposure: 2.0 });
+            // u_clearColor set from MeshRenderer
+        this.RP_ToneMapToScreen_mat.lights = false;
+
+        let pthis = this;
+
+        this.RP_ToneMapToScreen = new RenderPass(
+            RenderPass.POSTPROCESS,
+            function (textureMap, additionalData) {},
+            function (textureMap, additionalData) {
+                return { material: pthis.RP_ToneMapToScreen_mat,
+                         textures: [ textureMap[this.input_texture] ] };
+            },
+            function (textureMap, additionalData) {},
+            RenderPass.SCREEN,
+            null
+        );
+        this.RP_ToneMapToScreen.input_texture = "color_main";
+        this.RP_ToneMapToScreen.view_setup = function(vport) { this.viewport = vport; };
+
+        this.queue.pushRenderPass(this.RP_ToneMapToScreen);
+    }
+
+    //=============================================================================
+
+    make_RP_GBuffer()
+    {
+        this.RP_GBuffer_mat = new CustomShaderMaterial("GBufferMini");
+        this.RP_GBuffer_mat.lights = false;
+        this.RP_GBuffer_mat.side = FRONT_AND_BACK_SIDE;
+
+        this.RP_GBuffer_mat_flat = new CustomShaderMaterial("GBufferMini");
+        this.RP_GBuffer_mat_flat.lights = false;
+        this.RP_GBuffer_mat_flat.side = FRONT_AND_BACK_SIDE;
+        this.RP_GBuffer_mat_flat.normalFlat = true;
+
+        let pthis = this;
+
+        this.RP_GBuffer = new RenderPass(
+            RenderPass.BASIC,
+            function (textureMap, additionalData) {},
+            function (textureMap, additionalData) {
+                pthis.renderer._outlineEnabled = true;
+                pthis.renderer._outlineArray = this.obj_list;
+                pthis.renderer._defaultOutlineMat = pthis.RP_GBuffer_mat;
+                pthis.renderer._defaultOutlineMatFlat = pthis.RP_GBuffer_mat_flat;
+                pthis.renderer._fillRequiredPrograms(pthis.RP_GBuffer_mat.requiredProgram(pthis.renderer));
+                pthis.renderer._fillRequiredPrograms(pthis.RP_GBuffer_mat_flat.requiredProgram(pthis.renderer));
+                for (const o3d of this.obj_list) {
+                    if (o3d.outlineMaterial)
+                        pthis.renderer._fillRequiredPrograms(o3d.outlineMaterial.requiredProgram(pthis.renderer));
+                }
+                return { scene: pthis.scene, camera: pthis.camera };
+            },
+            function (textureMap, additionalData) {
+                pthis.renderer._outlineEnabled = false; // can remain true if not all progs are loaded
+                pthis.renderer._outlineArray = null;
+            },
+            RenderPass.TEXTURE,
+            null,
+            "depth_gbuff",
+            [
+                {id: "normal",  textureConfig: RenderPass.DEFAULT_RGBA16F_TEXTURE_CONFIG,
+                 clearColorArray: this.clear_zero_f32arr},
+                {id: "view_dir", textureConfig: RenderPass.DEFAULT_RGBA16F_TEXTURE_CONFIG,
+                 clearColorArray: this.clear_zero_f32arr}
+            ]
+        );
+        this.RP_GBuffer.view_setup = function (vport) { this.viewport = vport; };
+
+        // TODO: No push, GBuffer/Outline passes should be handled separately as there can be more of them.
+        this.queue.pushRenderPass(this.RP_GBuffer);
+    }
+
+    make_RP_Outline()
+    {
+        this.RP_Outline_mat = new CustomShaderMaterial("outline",
+          { scale: 1.0,
+            edgeColor: [ 1.4, 0.0, 0.8, 1.0 ],
+            _DepthThreshold: 6.0,
+            _NormalThreshold: 0.6, // 0.4,
+            _DepthNormalThreshold: 0.5,
+            _DepthNormalThresholdScale: 7.0 });
+        this.RP_Outline_mat.addSBFlag("DISCARD_NON_EDGE");
+        this.RP_Outline_mat.lights = false;
+
+        let pthis = this;
+
+        this.RP_Outline = new RenderPass(
+            RenderPass.POSTPROCESS,
+            function (textureMap, additionalData) {},
+            function (textureMap, additionalData) {
+                return { material: pthis.RP_Outline_mat,
+                         textures: [ textureMap["depth_gbuff"],
+                                     textureMap[this.intex_normal],
+                                     textureMap[this.intex_view_dir] ] };
+            },
+            function (textureMap, additionalData) {},
+            RenderPass.TEXTURE,
+            null,
+            null,
+            [
+                {id: "color_outline", textureConfig: RenderPass.DEFAULT_RGBA16F_TEXTURE_CONFIG,
+                 clearColorArray: this.clear_zero_f32arr}
+            ]
+        );
+        this.RP_Outline.intex_normal = "normal";
+        this.RP_Outline.intex_view_dir = "view_dir";
+        this.RP_Outline.view_setup = function (vport) { this.viewport = vport; };
+
+        // TODO: No push, GBuffer/Outline passes should be handled separately as there can be more of them.
+        this.queue.pushRenderPass(this.RP_Outline);
+    }
+
+    make_RP_GaussHVandBlend()
+    {
+        let pthis = this;
+
+        this.RP_GaussH_mat = new CustomShaderMaterial("gaussBlur", {horizontal: true, power: 4.0});
+        this.RP_GaussH_mat.lights = false;
+
+        this.RP_GaussH = new RenderPass(
+            RenderPass.POSTPROCESS,
+            function(textureMap, additionalData) {},
+            function(textureMap, additionalData) {
+                return {material: pthis.RP_GaussH_mat, textures: [textureMap[this.intex]]};
+            },
+            function(textureMap, additionalData) {},
+            RenderPass.TEXTURE,
+            null,
+            null,
+            [
+                {id: "gauss_h", textureConfig: RenderPass.DEFAULT_RGBA16F_TEXTURE_CONFIG}
+            ]
+        );
+        this.RP_GaussH.intex = "color_outline";
+        this.RP_GaussH.view_setup = function (vport) { this.viewport = vport; };
+
+        this.RP_GaussV_mat = new CustomShaderMaterial("gaussBlur", {horizontal: false, power: 4.0});
+        this.RP_GaussV_mat.lights = false;
+
+        this.RP_GaussV = new RenderPass(
+            RenderPass.POSTPROCESS,
+            function(textureMap, additionalData) {},
+            function(textureMap, additionalData) {
+                return {material: pthis.RP_GaussV_mat, textures: [textureMap[this.intex]]};
+            },
+            function(textureMap, additionalData) {},
+            RenderPass.TEXTURE,
+            null,
+            null,
+            [
+                {id: "gauss_hv", textureConfig: RenderPass.DEFAULT_RGBA16F_TEXTURE_CONFIG}
+            ]
+        );
+        this.RP_GaussV.intex = "gauss_h";
+        this.RP_GaussV.view_setup = function (vport) { this.viewport = vport; };
+
+        this.RP_Blend_mat = new CustomShaderMaterial("blendingAdditive");
+        this.RP_Blend_mat.lights = false;
+
+        this.RP_Blend = new RenderPass(
+            RenderPass.POSTPROCESS,
+            function(textureMap, additionalData) {},
+            function(textureMap, additionalData) {
+                return {material: pthis.RP_Blend_mat,
+                        textures: [textureMap[this.intex_outline_blurred],
+                                   textureMap[this.intex_main]]};
+            },
+            function(textureMap, additionalData) {},
+            // Target
+            RenderPass.TEXTURE,
+            null,
+            null,
+            [
+                {id: "color_final", textureConfig: RenderPass.DEFAULT_RGBA16F_TEXTURE_CONFIG}
+            ]
+        );
+        this.RP_Blend.intex_outline_blurred = "gauss_hv";
+        this.RP_Blend.intex_main = "color_main";
+        this.RP_Blend.view_setup = function (vport) { this.viewport = vport; };
+
+        this.queue.pushRenderPass(this.RP_GaussH);
+        this.queue.pushRenderPass(this.RP_GaussV);
+        this.queue.pushRenderPass(this.RP_Blend);
+    }
+
+    //=============================================================================
+    // HighPass and Bloom
+    //=============================================================================
+
+    make_RP_HighPassGaussBloom()
+    {
+        let pthis = this;
+        // let hp = new CustomShaderMaterial("highPass", {MODE: HIGHPASS_MODE_BRIGHTNESS, targetColor: [0.2126, 0.7152, 0.0722], threshold: 0.75});
+        let hp = new CustomShaderMaterial("highPass", { MODE: HIGHPASS_MODE_DIFFERENCE,
+                                             targetColor: [0x0/255, 0x0/255, 0xff/255], threshold: 0.1});
+        console.log("XXXXXXXX", hp);
+        // let hp = new CustomShaderMaterial("highPassReve");
+        this.RP_HighPass_mat = hp;
+        this.RP_HighPass_mat.lights = false;
+
+        this.RP_HighPass = new RenderPass(
+            RenderPass.POSTPROCESS,
+            function (textureMap, additionalData) {},
+            function (textureMap, additionalData) {
+                return { material: pthis.RP_HighPass_mat, textures: [textureMap["color_ssaa_super"]] };
+            },
+            function (textureMap, additionalData) {},
+            RenderPass.TEXTURE,
+            null,
+            // XXXXXX MT: this was "dt", why not null ????
+            null, // "dt",
+            [ {id: "color_high_pass", textureConfig: RenderPass.DEFAULT_RGBA_TEXTURE_CONFIG} ]
+        );
+        this.RP_HighPass.view_setup = function (vport) { this.viewport = { width: vport.width*pthis.SSAA_value, height: vport.height*pthis.SSAA_value }; };
+        this.queue.pushRenderPass(this.RP_HighPass);
+
+        this.RP_Gauss1_mat = new CustomShaderMaterial("gaussBlur", {horizontal: true, power: 1.0});
+        this.RP_Gauss1_mat.lights = false;
+
+        this.RP_Gauss1 = new RenderPass(
+            RenderPass.POSTPROCESS,
+            function (textureMap, additionalData) {},
+            function (textureMap, additionalData) {
+                return { material: pthis.RP_Gauss1_mat, textures: [textureMap["color_high_pass"]] };
+            },
+            function (textureMap, additionalData) {},
+            RenderPass.TEXTURE,
+            null,
+            null,
+            [ {id: "color_gauss_half", textureConfig: RenderPass.DEFAULT_RGBA_TEXTURE_CONFIG} ]
+        );
+        this.RP_Gauss1.view_setup = function (vport) { this.viewport = { width: vport.width*pthis.SSAA_value, height: vport.height*pthis.SSAA_value }; };
+        this.queue.pushRenderPass(this.RP_Gauss1);
+
+        this.RP_Gauss2_mat = new CustomShaderMaterial("gaussBlur", {horizontal: false, power: 1.0});
+        this.RP_Gauss2_mat.lights = false;
+
+        this.RP_Gauss2 = new RenderPass(
+            RenderPass.POSTPROCESS,
+            function (textureMap, additionalData) {},
+            function (textureMap, additionalData) {
+                return { material: pthis.RP_Gauss2_mat, textures: [textureMap["color_gauss_half"]] };
+            },
+            function (textureMap, additionalData) {},
+            RenderPass.TEXTURE,
+            null,
+            null,
+            [ {id: "color_gauss_full", textureConfig: RenderPass.DEFAULT_RGBA_TEXTURE_CONFIG} ]
+        );
+        this.RP_Gauss2.view_setup = function (vport) { this.viewport = { width: vport.width*pthis.SSAA_value, height: vport.height*pthis.SSAA_value }; };
+        this.queue.pushRenderPass(this.RP_Gauss2);
+
+        this.RP_Bloom_mat = new CustomShaderMaterial("bloom");
+        this.RP_Bloom_mat.lights = false;
+
+        this.RP_Bloom = new RenderPass(
+            RenderPass.POSTPROCESS,
+            function (textureMap, additionalData) {},
+            function (textureMap, additionalData) {
+                return { material: pthis.RP_Bloom_mat, textures: [textureMap["color_gauss_full"], textureMap["color_ssaa_super"]] };
+            },
+            function (textureMap, additionalData) {},
+            RenderPass.TEXTURE,
+            null,
+            null,
+            [ {id: "color_bloom", textureConfig: RenderPass.DEFAULT_RGBA_TEXTURE_CONFIG} ]
+        );
+        this.RP_Bloom.view_setup = function (vport) { this.viewport = { width: vport.width*pthis.SSAA_value, height: vport.height*pthis.SSAA_value }; };
+        this.queue.pushRenderPass(this.RP_Bloom);
+    }
+}

--- a/src/contrib/RendeQuTor.js
+++ b/src/contrib/RendeQuTor.js
@@ -24,7 +24,7 @@ export class RendeQuTor
           [ this.PRP_depth2r_mat.requiredProgram(this.renderer)
           ]);
 
-          this.SSAA_value = 1;
+        this.SSAA_value = 1;
 
         this.clear_zero_f32arr = new Float32Array([0,0,0,0]);
 
@@ -393,7 +393,9 @@ export class RendeQuTor
             // Outputs
             [ { id: "color_main", textureConfig: RenderPass.DEFAULT_RGBA16F_TEXTURE_CONFIG } ]
         );
-        this.RP_SSAA_Super.view_setup = function (vport) { this.viewport = { width: vport.width*pthis.SSAA_value, height: vport.height*pthis.SSAA_value }; };
+        this.RP_SSAA_Super.view_setup = function (vport) {
+             this.viewport = { width: vport.width*pthis.SSAA_value, height: vport.height*pthis.SSAA_value };
+            };
 
         this.queue.pushRenderPass(this.RP_SSAA_Super);
     }

--- a/src/core/Canvas.js
+++ b/src/core/Canvas.js
@@ -7,10 +7,6 @@ import {_Math} from '../math/Math.js';
 
 export class Canvas {
 
-
-	_pixelRatio = 1;
-
-
 	//CONST
 	constructor(parentDOM) {
 		this._canvasDOM = this.generateCanvasDOM();
@@ -81,7 +77,7 @@ export class Canvas {
 	updateSize(){
 		//set the internal size to match
 		//set the size of the drawing buffer
-		this._canvasDOM.width = this._canvasDOM.clientWidth * this.pixelRatio;
-		this._canvasDOM.height = this._canvasDOM.clientHeight * this.pixelRatio;
+		this._canvasDOM.width = Math.floor(this._canvasDOM.clientWidth * this.pixelRatio);
+		this._canvasDOM.height = Math.floor(this._canvasDOM.clientHeight * this.pixelRatio);
 	}
 }

--- a/src/lights/PointLight.js
+++ b/src/lights/PointLight.js
@@ -42,8 +42,7 @@ export class PointLight extends Light {
 		this.cameraGroup.add(cameraZp);
 		this.cameraGroup.add(cameraZn);
 
-		
-		this.shadowmap = new CubeTexture();
+		this.shadowmap = new CubeTexture( { size: args.smap_size ? args.smap_size : 256 } );
 	}
 
 	set distance(dist) {

--- a/src/loaders/ShaderLoader.js
+++ b/src/loaders/ShaderLoader.js
@@ -330,10 +330,13 @@ export class ShaderLoader {
 	 * for packaging, most likely called with ShaderLoader.sAllPrograms as argument.
 	 * One might want to delete urls property of each element.
 	*/
-	resolvePrograms (name_list) {
-		let prog_list = [];
+	resolvePrograms (name_list, delete_urls=true) {
+		let prog_list = {};
 		for (let name of name_list) {
-			prog_list.push(structuredClone(this._programs[name]));
+			let details = structuredClone(this._programs[name]);
+			if (delete_urls)
+				delete details.urls;
+			prog_list[name] = details;
 		}
 		return prog_list;
 	}

--- a/src/shaders/custom/drawToTexture/copyDepthToRed.frag
+++ b/src/shaders/custom/drawToTexture/copyDepthToRed.frag
@@ -1,0 +1,28 @@
+#version 300 es
+precision highp float;
+precision highp sampler2D;
+
+struct Material {
+    #if (TEXTURE)
+        sampler2D texture0;
+    #fi
+};
+
+uniform Material material;
+
+#if (TEXTURE)
+    in vec2 fragUV;
+#fi
+
+out float color;
+
+
+void main() {
+    #if (TEXTURE)
+        // TEST, write known numbers into result
+        // color.r = 0.5370;
+        // color.r = fragUV.x;
+
+        color = texture(material.texture0, fragUV).r;
+    #fi
+}

--- a/src/shaders/custom/drawToTexture/copyDepthToRed.vert
+++ b/src/shaders/custom/drawToTexture/copyDepthToRed.vert
@@ -1,0 +1,20 @@
+#version 300 es
+precision highp float;
+
+in vec3 VPos; // Vertex position
+
+#if (TEXTURE)
+    in vec2 uv;  // Texture coordinate
+#fi
+
+// Output quad texture coordinates
+out vec2 fragUV;
+
+void main() {
+    gl_Position = vec4(VPos, 1.0);
+
+    #if (TEXTURE)
+        // Pass-through texture coordinate
+        fragUV = uv;
+    #fi
+}

--- a/src/shaders/programs.json
+++ b/src/shaders/programs.json
@@ -153,6 +153,14 @@
         }
     },
 
+    "custom_copyDepthToRed" : {
+        "description":  "Copy depth buffer values to R component (R32F) for picking depth extraction.",
+        "shaders": {
+            "vertex":   "custom/drawToTexture/copyDepthToRed.vert",
+            "fragment": "custom/drawToTexture/copyDepthToRed.frag"
+        }
+    },
+
     "custom_overlayTextures": {
         "description": "Default gl2 program used for testing.",
         "shaders": {


### PR DESCRIPTION
* Add src/contrib and dist/reve folders to distribute low-level ROOT-Eve functionality with RenderCore as well as to allow packaging a subset of RenderCore for ROOT.

* RendeQuTor: create also to-screen pass so the viewer can call it instead of the tone-mapped version.

* Canvas: Floor canvas size calculation with pixel-ratio, client sizes can be floats.

* PointLight: Add ctor argument args.smap_size (shadow_map_texture_size). This is passed to CubeMap constructor. Default size is 256.