### PR TITLE
Fix error in ZShape rendering on OSX Chrome and Safari

### DIFF
--- a/src/shaders/basic/basic_zshape_template.frag
+++ b/src/shaders/basic/basic_zshape_template.frag
@@ -21,7 +21,6 @@ struct PLight {
     //float decay;
 
     mat4 VPMat;
-    samplerCube shadowmap;
     bool castShadows;
     bool hardShadows;
     float minBias;

--- a/src/shaders/basic/basic_zshape_template.vert
+++ b/src/shaders/basic/basic_zshape_template.vert
@@ -47,7 +47,6 @@ struct PLight {
     //float decay;
 
     mat4 VPMat;
-    samplerCube shadowmap;
     bool castShadows;
     bool hardShadows;
     float minBias;


### PR DESCRIPTION
ZShape instances were not rendered on OSX Chrome and Safari.
This was the message in the console 
```
GL_INVALID_OPERATION: Two textures of different types use the same sampler location 
```
I saw this post that inspired to remove sampleCube from zshape shaders:
https://forum.babylonjs.com/t/cube-texture-shader-material-errors/21649

This fixed the problem.
The samplerCube was not used in the shader. It was part of PLIGHTS cut&paste block I forgot to remove from the start.